### PR TITLE
Fix consumption API route and add coverage

### DIFF
--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -170,7 +170,7 @@ class SommOSAPI {
     }
 
     async recordConsumption(consumptionData) {
-        return this.request('/inventory/consumption', {
+        return this.request('/inventory/consume', {
             method: 'POST',
             body: JSON.stringify(consumptionData)
         });

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -964,7 +964,7 @@ class SommOS {
                 service_date: new Date().toISOString()
             };
             
-            // Submit to API (you'll need to implement this endpoint)
+            // Submit consumption record to backend API
             await this.api.recordConsumption(consumptionData);
             
             this.ui.showToast(`Successfully recorded service of ${quantity} bottle(s)`, 'success');


### PR DESCRIPTION
## Summary
- update `SommOSAPI.recordConsumption` to call the existing `/inventory/consume` endpoint
- clarify the consumption submission comment in the app logic to reflect the live backend route
- extend the frontend API test suite to cover `recordConsumption` and mock IndexedDB so the new test can exercise the real client

## Testing
- npm test -- tests/frontend/frontend.test.js *(fails: existing suite expectations/coverage thresholds outside the modified API tests)*
- npm test -- tests/frontend/frontend.test.js -t "record service consumption via API" *(fails coverage threshold enforcement when only the targeted test runs)*

------
https://chatgpt.com/codex/tasks/task_e_68d55d4d51c4832b96e6e843728f422e