### PR TITLE
Enhance wine pairing input builder

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -586,6 +586,25 @@ select:focus {
     font-weight: 600;
 }
 
+.btn.small {
+    padding: 0.6rem 1.1rem;
+    font-size: 0.9rem;
+    font-weight: 500;
+    gap: 0.4rem;
+}
+
+.btn.ghost {
+    background: transparent;
+    border-color: var(--border);
+    color: var(--text-secondary);
+}
+
+.btn.ghost:hover {
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--text-primary);
+    border-color: var(--border-light);
+}
+
 .btn:disabled {
     opacity: 0.6;
     cursor: not-allowed;
@@ -929,6 +948,157 @@ select:focus {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 3rem;
+}
+
+.dish-builder {
+    background: rgba(15, 25, 46, 0.55);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius-medium);
+    padding: 1.5rem;
+    margin-top: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    box-shadow: 0 10px 30px rgba(3, 6, 15, 0.35);
+}
+
+.builder-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.builder-header label {
+    font-weight: 600;
+    color: var(--text-primary);
+    font-size: 1.05rem;
+}
+
+.builder-header .optional {
+    color: var(--accent-color);
+    font-size: 0.85rem;
+    margin-left: 0.35rem;
+}
+
+.builder-header .helper-text {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+.builder-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.builder-column {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.builder-column label {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+
+.builder-column input,
+.builder-column select {
+    background: rgba(9, 15, 32, 0.7);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius-small);
+    padding: 0.75rem 1rem;
+    color: var(--text-primary);
+    transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.builder-column input::placeholder {
+    color: var(--text-muted);
+}
+
+.builder-column input:focus,
+.builder-column select:focus {
+    border-color: var(--accent-color);
+    background: rgba(9, 15, 32, 0.85);
+}
+
+.flavor-tag-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.flavor-label {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    font-weight: 600;
+}
+
+.flavor-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.flavor-tag {
+    padding: 0.45rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 0.85rem;
+    transition: all var(--transition-fast);
+}
+
+.flavor-tag:hover,
+.flavor-tag:focus {
+    border-color: var(--accent-color);
+    color: var(--text-primary);
+    background: rgba(156, 124, 255, 0.15);
+}
+
+.flavor-tag.selected {
+    background: var(--gradient-primary);
+    color: #fff;
+    border-color: var(--accent-color);
+    box-shadow: 0 6px 16px rgba(156, 124, 255, 0.25);
+}
+
+.builder-preview {
+    background: rgba(9, 15, 32, 0.65);
+    border: 1px dashed var(--border);
+    border-radius: var(--border-radius-small);
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.preview-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-muted);
+    font-weight: 600;
+}
+
+#dish-builder-preview {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+.builder-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: flex-end;
+}
+
+.builder-actions .btn {
+    min-width: 150px;
 }
 
 .pairing-results {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -193,7 +193,91 @@
                             <label for="dish-input">Dish Description</label>
                             <textarea id="dish-input" placeholder="Describe the dish you're serving (e.g., grilled salmon with lemon herbs)" rows="3"></textarea>
                         </div>
-                        
+
+                        <div class="form-group dish-builder" aria-describedby="dish-builder-helper">
+                            <div class="builder-header">
+                                <label>Build a Dish Description <span class="optional">(Optional)</span></label>
+                                <p id="dish-builder-helper" class="helper-text">Choose a few quick details and we'll craft a rich dish description that you can still edit.</p>
+                            </div>
+
+                            <div class="builder-grid">
+                                <div class="builder-column">
+                                    <label for="dish-main-ingredient">Main Ingredient</label>
+                                    <input type="text" id="dish-main-ingredient" placeholder="e.g., salmon, beef tenderloin, wild mushrooms">
+                                </div>
+                                <div class="builder-column">
+                                    <label for="dish-cooking-technique">Cooking Technique</label>
+                                    <select id="dish-cooking-technique">
+                                        <option value="">Select technique</option>
+                                        <option value="grilled">Grilled</option>
+                                        <option value="roasted">Roasted</option>
+                                        <option value="pan-seared">Pan-seared</option>
+                                        <option value="braised">Braised</option>
+                                        <option value="poached">Poached</option>
+                                        <option value="smoked">Smoked</option>
+                                        <option value="slow-cooked">Slow-cooked</option>
+                                    </select>
+                                </div>
+                                <div class="builder-column">
+                                    <label for="dish-cuisine-style">Cuisine Style</label>
+                                    <select id="dish-cuisine-style">
+                                        <option value="">Select cuisine</option>
+                                        <option value="Mediterranean">Mediterranean</option>
+                                        <option value="French">French</option>
+                                        <option value="Italian">Italian</option>
+                                        <option value="Spanish">Spanish</option>
+                                        <option value="Japanese">Japanese</option>
+                                        <option value="Thai">Thai</option>
+                                        <option value="Latin">Latin American</option>
+                                        <option value="Modern">Modern fusion</option>
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div class="builder-grid">
+                                <div class="builder-column">
+                                    <label for="dish-accompaniments">Accompaniments</label>
+                                    <input type="text" id="dish-accompaniments" placeholder="e.g., roasted root vegetables, citrus beurre blanc">
+                                </div>
+                                <div class="builder-column">
+                                    <label for="dish-intensity">Intensity</label>
+                                    <select id="dish-intensity">
+                                        <option value="">Select intensity</option>
+                                        <option value="light">Light</option>
+                                        <option value="medium">Medium</option>
+                                        <option value="rich">Rich</option>
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div class="flavor-tag-group" role="group" aria-label="Flavor notes">
+                                <span class="flavor-label">Flavor Highlights</span>
+                                <div class="flavor-tags">
+                                    <button type="button" class="flavor-tag" data-flavor="bright citrus">Citrus</button>
+                                    <button type="button" class="flavor-tag" data-flavor="herbaceous">Herbal</button>
+                                    <button type="button" class="flavor-tag" data-flavor="smoky">Smoky</button>
+                                    <button type="button" class="flavor-tag" data-flavor="savory umami">Umami</button>
+                                    <button type="button" class="flavor-tag" data-flavor="spiced">Spiced</button>
+                                    <button type="button" class="flavor-tag" data-flavor="creamy">Creamy</button>
+                                    <button type="button" class="flavor-tag" data-flavor="sweet and tangy">Sweet &amp; Tangy</button>
+                                    <button type="button" class="flavor-tag" data-flavor="earthy">Earthy</button>
+                                </div>
+                            </div>
+
+                            <div class="builder-preview" aria-live="polite" aria-atomic="true">
+                                <span class="preview-label">Preview</span>
+                                <p id="dish-builder-preview">Select details to see a suggested description.</p>
+                            </div>
+
+                            <div class="builder-actions">
+                                <button type="button" id="clear-dish-builder" class="btn ghost small">Clear Builder</button>
+                                <button type="button" id="apply-dish-builder" class="btn secondary small">
+                                    <span class="btn-icon">✨</span>
+                                    Use This Description
+                                </button>
+                            </div>
+                        </div>
+
                         <div class="form-row">
                             <div class="form-group">
                                 <label for="occasion-select">Occasion</label>


### PR DESCRIPTION
## Summary
- add an optional dish builder to the wine pairing form with structured fields and flavor tags to speed up descriptions
- style the new builder components and supporting button variants to match the existing UI
- wire up frontend logic to generate preview text, apply it to the pairing request, and reset the builder gracefully

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5a600365c832b843e4f8dc47e7f7e