### PR TITLE
Enhance procurement assistant workflows

### DIFF
--- a/backend/api/routes.js
+++ b/backend/api/routes.js
@@ -277,14 +277,17 @@ router.get('/inventory/ledger/:vintage_id', asyncHandler(async (req, res) => {
 // GET /api/procurement/opportunities
 // Get procurement opportunities
 router.get('/procurement/opportunities', asyncHandler(async (req, res) => {
-    const { region, wine_type, max_price, min_score } = req.query;
-    
+    const { region, regions, wine_type, wine_types, max_price, min_score, budget } = req.query;
+
     try {
         const opportunities = await procurementEngine.analyzeProcurementOpportunities({
             region,
+            regions,
             wine_type,
+            wine_types,
             max_price: max_price ? parseFloat(max_price) : undefined,
-            min_score: min_score ? parseInt(min_score) : undefined
+            budget: budget ? parseFloat(budget) : undefined,
+            min_score: min_score ? parseInt(min_score, 10) : undefined
         });
 
         res.json({
@@ -335,7 +338,7 @@ router.post('/procurement/analyze', asyncHandler(async (req, res) => {
 // Generate purchase order
 router.post('/procurement/order', asyncHandler(async (req, res) => {
     const { items, supplier_id, delivery_date, notes } = req.body;
-    
+
     if (!items || !Array.isArray(items) || items.length === 0) {
         return res.status(400).json({
             success: false,
@@ -343,10 +346,17 @@ router.post('/procurement/order', asyncHandler(async (req, res) => {
         });
     }
 
+    if (!supplier_id) {
+        return res.status(400).json({
+            success: false,
+            error: 'supplier_id is required'
+        });
+    }
+
     try {
         const order = await procurementEngine.generatePurchaseOrder(
-            items, 
-            supplier_id, 
+            items,
+            supplier_id,
             delivery_date, 
             notes
         );

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -290,7 +290,7 @@
                             <div class="stat-card">
                                 <div class="stat-icon">💡</div>
                                 <div class="stat-content">
-                                    <div class="stat-number" id="procurement-opportunities">-</div>
+                                    <div class="stat-number" id="procurement-opportunity-count">-</div>
                                     <div class="stat-label">Opportunities</div>
                                 </div>
                             </div>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1482,7 +1482,7 @@ class SommOS {
     async loadProcurementStats() {
         try {
             // For now, show placeholder stats
-            document.getElementById('procurement-opportunities').textContent = '12';
+            document.getElementById('procurement-opportunity-count').textContent = '12';
             document.getElementById('potential-savings').textContent = '$15,240';
             document.getElementById('pending-orders').textContent = '3';
         } catch (error) {
@@ -1513,10 +1513,13 @@ class SommOS {
             };
             
             const opportunities = await this.api.getProcurementOpportunities(filters);
-            
+
             if (opportunities.success && opportunities.data) {
-                this.displayProcurementOpportunities(opportunities.data);
-                this.ui.showToast(`Found ${opportunities.data.length} procurement opportunities`, 'success');
+                this.displayProcurementOverview(opportunities.data.summary);
+                this.displayProcurementOpportunities(opportunities.data.opportunities);
+
+                const opportunityCount = opportunities.data.summary?.total_opportunities ?? opportunities.data.opportunities?.length ?? 0;
+                this.ui.showToast(`Found ${opportunityCount} procurement opportunities`, 'success');
             } else {
                 throw new Error('Failed to get procurement opportunities');
             }
@@ -1526,29 +1529,55 @@ class SommOS {
         }
     }
 
+    displayProcurementOverview(summary) {
+        if (!summary) {
+            return;
+        }
+
+        const opportunitiesElement = document.getElementById('procurement-opportunity-count');
+        const savingsElement = document.getElementById('potential-savings');
+        const pendingOrdersElement = document.getElementById('pending-orders');
+
+        if (opportunitiesElement) {
+            opportunitiesElement.textContent = summary.total_opportunities ?? '-';
+        }
+
+        if (savingsElement) {
+            const savings = (summary.projected_value || 0) - (summary.recommended_spend || 0);
+            savingsElement.textContent = `$${Number.isFinite(savings) ? savings.toFixed(2) : '0.00'}`;
+        }
+
+        if (pendingOrdersElement) {
+            pendingOrdersElement.textContent = summary.urgent_actions ?? '0';
+        }
+    }
+
     displayProcurementOpportunities(opportunities) {
         const grid = document.getElementById('procurement-opportunities');
-        
+
         if (!opportunities || opportunities.length === 0) {
             grid.innerHTML = '<div class="opportunities-placeholder"><p>No procurement opportunities found with current filters</p></div>';
             return;
         }
-        
+
         grid.innerHTML = opportunities.map(opportunity => `
             <div class="opportunity-card">
                 <div class="opportunity-header">
                     <h4>${opportunity.wine_name || 'Wine Opportunity'}</h4>
-                    <div class="opportunity-score">${Math.round((opportunity.score || 0.8) * 100)}%</div>
+                    <div class="opportunity-score">${Math.round(((opportunity.score?.total) || opportunity.score || 0.8) * 100)}%</div>
                 </div>
                 <div class="opportunity-details">
                     <p><strong>Producer:</strong> ${opportunity.producer || 'N/A'}</p>
                     <p><strong>Region:</strong> ${opportunity.region || 'N/A'}</p>
-                    <p><strong>Estimated Value:</strong> $${opportunity.estimated_value || 'TBD'}</p>
+                    <p><strong>Estimated Value:</strong> $${opportunity.estimated_value ?? 'TBD'}</p>
                     <p><strong>Recommended Quantity:</strong> ${opportunity.recommended_quantity || 12} bottles</p>
+                    <p><strong>Projected Investment:</strong> $${opportunity.estimated_investment ?? 'TBD'}</p>
+                    <p><strong>Urgency:</strong> ${opportunity.urgency || 'Moderate'}</p>
                 </div>
                 <div class="opportunity-reasoning">
                     <h5>Why this opportunity:</h5>
                     <p>${opportunity.reasoning || 'Based on current inventory gaps and market analysis'}</p>
+                    <p><strong>Confidence:</strong> ${(opportunity.confidence ? Math.round(opportunity.confidence * 100) : 70)}%</p>
                 </div>
                 <div class="opportunity-actions">
                     <button class="btn primary" onclick="app.analyzePurchaseDecision('${opportunity.wine_id}', '${opportunity.supplier_id}')">


### PR DESCRIPTION
## Summary
- enrich procurement engine scoring to output detailed opportunity summaries, budget alignment, and stronger purchase decision insights
- tighten API and mock behaviours for procurement endpoints with budget-aware filters and supplier validation
- refresh procurement dashboard UI to consume the enriched API response and show opportunity metrics
- extend backend API tests to cover new procurement shapes, error branches, and validation paths

## Testing
- npm test -- --runTestsByPath tests/backend/api.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d5a7c2bd2c832b98570d5aeed89ddd