### PR TITLE
Enhance wine catalog presentation with score summaries

### DIFF
--- a/backend/api/routes.js
+++ b/backend/api/routes.js
@@ -375,8 +375,11 @@ router.get('/wines', asyncHandler(async (req, res) => {
     try {
         const db = Database.getInstance();
         let query = `
-            SELECT w.*, v.year, v.quality_score, v.peak_drinking_start, v.peak_drinking_end,
-                   COALESCE(SUM(s.quantity), 0) as total_stock
+            SELECT w.*, v.year, v.quality_score, v.weather_score, v.critic_score,
+                   v.peak_drinking_start, v.peak_drinking_end,
+                   COALESCE(SUM(s.quantity), 0) as total_stock,
+                   ROUND(AVG(COALESCE(s.cost_per_bottle, s.current_value)), 2) as avg_cost_per_bottle,
+                   COALESCE(SUM(s.quantity * COALESCE(s.current_value, s.cost_per_bottle, 0)), 0) as total_value
             FROM Wines w
             LEFT JOIN Vintages v ON w.id = v.wine_id
             LEFT JOIN Stock s ON v.id = s.vintage_id
@@ -469,21 +472,35 @@ router.get('/wines/:id', asyncHandler(async (req, res) => {
         
         // Get vintages
         const vintages = await db.all(`
-            SELECT v.*, COALESCE(SUM(s.quantity), 0) as total_stock
+            SELECT v.*,
+                   COALESCE(SUM(s.quantity), 0) as total_stock,
+                   ROUND(AVG(COALESCE(s.cost_per_bottle, s.current_value)), 2) as avg_cost_per_bottle,
+                   COALESCE(SUM(s.quantity * COALESCE(s.current_value, s.cost_per_bottle, 0)), 0) as total_value
             FROM Vintages v
             LEFT JOIN Stock s ON v.id = s.vintage_id
             WHERE v.wine_id = ?
             GROUP BY v.id
             ORDER BY v.year DESC
         `, [id]);
-        
+
         // Get aliases
         const aliases = await db.all('SELECT * FROM Aliases WHERE wine_id = ?', [id]);
-        
+
+        const primaryVintage = vintages[0] || {};
+        const totalStock = vintages.reduce((sum, vintage) => sum + (vintage.total_stock || 0), 0);
+        const totalValue = vintages.reduce((sum, vintage) => sum + (vintage.total_value || 0), 0);
+        const averageCost = totalStock > 0 ? Number((totalValue / totalStock).toFixed(2)) : null;
+
         res.json({
             success: true,
             data: {
                 ...wine,
+                quality_score: wine.quality_score ?? primaryVintage.quality_score ?? null,
+                weather_score: wine.weather_score ?? primaryVintage.weather_score ?? null,
+                critic_score: wine.critic_score ?? primaryVintage.critic_score ?? null,
+                total_stock: totalStock,
+                total_value: Number(totalValue.toFixed(2)),
+                avg_cost_per_bottle: averageCost,
                 vintages,
                 aliases
             }

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -2314,6 +2314,35 @@ select:focus {
     font-size: 0.85rem;
 }
 
+.catalog-card .wine-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.catalog-card .wine-card-body {
+    margin-top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.wine-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.wine-meta .meta-item {
+    background: var(--surface-elevated);
+    padding: 0.25rem 0.6rem;
+    border-radius: var(--border-radius-small);
+    border: 1px solid var(--border-light);
+}
+
 .catalog-card .wine-stats {
     display: flex;
     justify-content: space-between;
@@ -2322,6 +2351,32 @@ select:focus {
     padding-top: 1rem;
     border-top: 1px solid var(--border);
     font-size: 0.9rem;
+    gap: 1rem;
+}
+
+.catalog-card .wine-stats .stat-block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    flex: 1;
+}
+
+.catalog-card .wine-stats .stat-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-secondary);
+}
+
+.catalog-card .wine-stats .stat-value {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.catalog-card .wine-stats .stat-unit {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
 }
 
 .catalog-card .stock {
@@ -2357,6 +2412,158 @@ select:focus {
     transform: translateX(4px);
 }
 
+.wine-score-summary {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-top: 0.75rem;
+}
+
+.wine-card-body .wine-score-summary,
+.wine-metrics .wine-score-summary {
+    margin-top: 0;
+}
+
+.wine-score-summary .score-chip {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.75rem 1rem;
+    border-radius: var(--border-radius-medium);
+    border: 1px solid var(--border);
+    background: var(--surface-elevated);
+    min-width: 130px;
+}
+
+.wine-score-summary .score-chip.overall {
+    background: var(--gradient-primary);
+    color: white;
+    border: none;
+    box-shadow: 0 8px 20px rgba(139, 90, 60, 0.25);
+}
+
+.wine-score-summary .score-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.85;
+}
+
+.wine-score-summary .score-value {
+    font-size: 1.5rem;
+    font-weight: 700;
+    display: flex;
+    align-items: baseline;
+    gap: 0.25rem;
+}
+
+.score-unit {
+    font-size: 0.75rem;
+    font-weight: 500;
+    opacity: 0.8;
+}
+
+.score-breakdown {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.score-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--surface-elevated);
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+.score-pill .pill-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.score-pill .pill-value {
+    font-weight: 600;
+    color: var(--text-primary);
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.25rem;
+}
+
+.score-pill.muted {
+    opacity: 0.6;
+    border-style: dashed;
+}
+
+.wine-score-summary.list {
+    justify-content: flex-end;
+    margin-top: 0;
+}
+
+.wine-score-summary.list .score-chip {
+    padding: 0.5rem 0.75rem;
+    min-width: auto;
+    background: var(--surface-elevated);
+    color: var(--text-primary);
+}
+
+.wine-score-summary.list .score-chip.overall {
+    background: var(--surface-elevated);
+    border: 1px solid var(--border);
+    box-shadow: none;
+}
+
+.wine-score-summary.list .score-value {
+    font-size: 1.2rem;
+}
+
+.wine-score-summary.list .score-breakdown {
+    display: none;
+}
+
+.wine-score-summary.detail,
+.wine-score-summary.modal {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius-medium);
+    padding: 1rem 1.5rem;
+    justify-content: space-between;
+    gap: 1.5rem;
+}
+
+.wine-score-summary.modal {
+    margin-bottom: 1.5rem;
+}
+
+.wine-score-summary.detail .score-chip.overall,
+.wine-score-summary.modal .score-chip.overall {
+    background: var(--accent-color);
+    box-shadow: none;
+}
+
+.wine-score-summary.detail .score-chip,
+.wine-score-summary.modal .score-chip {
+    background: var(--surface-elevated);
+    border: 1px solid var(--border-light);
+    color: var(--text-primary);
+}
+
+.wine-score-summary.detail .score-breakdown,
+.wine-score-summary.modal .score-breakdown {
+    flex: 1;
+}
+
+.wine-score-summary.detail .score-pill,
+.wine-score-summary.modal .score-pill {
+    background: var(--surface);
+}
+
 .wine-basic-info h4 {
     color: var(--text-primary);
     margin-bottom: 0.25rem;
@@ -2373,23 +2580,44 @@ select:focus {
     gap: 1rem;
     color: var(--text-secondary);
     font-size: 0.9rem;
+    flex-wrap: wrap;
+    align-items: center;
 }
 
 .wine-metrics {
     display: flex;
     flex-direction: column;
-    align-items: flex-end;
-    gap: 0.25rem;
-    font-size: 0.9rem;
+    gap: 0.75rem;
+    align-items: stretch;
 }
 
-.wine-metrics .stock {
+.wine-details .peak-window {
+    background: var(--surface-elevated);
+    border-radius: var(--border-radius-small);
+    border: 1px solid var(--border-light);
+    padding: 0.25rem 0.6rem;
+    color: var(--accent-color);
+    font-weight: 600;
+}
+
+.wine-metrics .metric-line {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    font-size: 0.85rem;
     color: var(--text-secondary);
 }
 
-.wine-metrics .value {
-    color: var(--success);
+.wine-metrics .metric-label {
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.75rem;
+}
+
+.wine-metrics .metric-value {
     font-weight: 600;
+    color: var(--text-primary);
+    text-align: right;
 }
 
 .catalog-pagination {
@@ -2521,6 +2749,147 @@ select:focus {
     flex-direction: column;
     gap: 2rem;
     margin-bottom: 2rem;
+}
+
+.peak-window {
+    margin-top: 1rem;
+    background: var(--surface);
+    border: 1px solid var(--border-light);
+    border-radius: var(--border-radius-medium);
+    padding: 0.75rem 1rem;
+}
+
+.peak-window strong {
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+}
+
+.peak-window p {
+    margin: 0.35rem 0 0 0;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.wine-inventory {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius-medium);
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.wine-inventory h4 {
+    margin: 0;
+    font-size: 1rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.inventory-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+}
+
+.inventory-metric {
+    background: var(--surface-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius-medium);
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.inventory-metric .metric-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-secondary);
+}
+
+.inventory-metric .metric-value {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.vintages-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.vintages-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.vintage-item {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius-medium);
+    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.vintage-item:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 30px var(--shadow-elevated);
+    border-color: var(--accent-color);
+}
+
+.vintage-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+}
+
+.vintage-year {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.vintage-stock {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.vintage-metrics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.vintage-metrics .metric {
+    background: var(--surface-elevated);
+    border-radius: var(--border-radius-small);
+    border: 1px solid var(--border-light);
+    padding: 0.35rem 0.6rem;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.vintage-metrics .score-pill {
+    background: var(--surface);
+}
+
+.vintage-actions {
+    display: flex;
+    justify-content: flex-end;
 }
 
 .wine-detail-section h4 {

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -555,6 +555,183 @@ class SommOS {
         };
         return icons[wineType] || '🍷';
     }
+
+    parseNumeric(value) {
+        if (value === null || value === undefined) {
+            return null;
+        }
+
+        const numeric = Number(value);
+        return Number.isFinite(numeric) ? numeric : null;
+    }
+
+    formatNumber(value) {
+        const numeric = this.parseNumeric(value);
+        if (numeric === null) {
+            return '—';
+        }
+
+        return new Intl.NumberFormat().format(numeric);
+    }
+
+    formatCurrency(value, { minimumFractionDigits = 0, maximumFractionDigits = 0 } = {}) {
+        const numeric = this.parseNumeric(value);
+        if (numeric === null) {
+            return '—';
+        }
+
+        return new Intl.NumberFormat(undefined, {
+            style: 'currency',
+            currency: 'USD',
+            minimumFractionDigits,
+            maximumFractionDigits
+        }).format(numeric);
+    }
+
+    getPeakDrinkingWindow(wine) {
+        const startOffset = this.parseNumeric(wine.peak_drinking_start);
+        const endOffset = this.parseNumeric(wine.peak_drinking_end);
+        const vintageYear = this.parseNumeric(wine.year);
+
+        if (startOffset === null && endOffset === null) {
+            return null;
+        }
+
+        if (vintageYear !== null) {
+            const startYear = startOffset !== null ? vintageYear + startOffset : null;
+            const endYear = endOffset !== null ? vintageYear + endOffset : null;
+
+            if (startYear && endYear) {
+                return `${startYear} – ${endYear}`;
+            }
+            if (startYear) {
+                return `${startYear}+`;
+            }
+            if (endYear) {
+                return `Drink by ${endYear}`;
+            }
+        }
+
+        if (startOffset !== null && endOffset !== null) {
+            return `${startOffset}-${endOffset} yrs`;
+        }
+
+        if (startOffset !== null) {
+            return `${startOffset}+ yrs`;
+        }
+
+        if (endOffset !== null) {
+            return `Drink within ${endOffset} yrs`;
+        }
+
+        return null;
+    }
+
+    parseScore(score) {
+        const numeric = this.parseNumeric(score);
+        if (numeric === null) {
+            return null;
+        }
+
+        return Math.max(0, Math.min(100, numeric));
+    }
+
+    calculateWineScore(wine) {
+        const quality = this.parseScore(wine.quality_score);
+        const critic = this.parseScore(wine.critic_score);
+        const weather = this.parseScore(wine.weather_score);
+
+        const weightedScores = [
+            { value: quality, weight: 0.5 },
+            { value: critic, weight: 0.3 },
+            { value: weather, weight: 0.2 }
+        ];
+
+        let weightedSum = 0;
+        let totalWeight = 0;
+
+        weightedScores.forEach(({ value, weight }) => {
+            if (value !== null) {
+                weightedSum += value * weight;
+                totalWeight += weight;
+            }
+        });
+
+        if (totalWeight === 0) {
+            return null;
+        }
+
+        return weightedSum / totalWeight;
+    }
+
+    getWineScoreData(wine) {
+        const qualityScore = this.parseScore(wine.quality_score);
+        const criticScore = this.parseScore(wine.critic_score);
+        const weatherScore = this.parseScore(wine.weather_score);
+        const availableScores = [qualityScore, criticScore, weatherScore].filter(score => score !== null);
+
+        return {
+            overallScore: this.calculateWineScore(wine),
+            qualityScore,
+            criticScore,
+            weatherScore,
+            hasScores: availableScores.length > 0
+        };
+    }
+
+    renderScoreValue(score, fallback = '—') {
+        const numeric = this.parseNumeric(score);
+        if (numeric === null) {
+            return fallback;
+        }
+
+        const rounded = Math.round(numeric);
+        return `${rounded}<span class="score-unit">pts</span>`;
+    }
+
+    renderScorePill(label, score) {
+        const numeric = this.parseNumeric(score);
+        if (numeric === null) {
+            return '';
+        }
+
+        return `
+            <div class="score-pill">
+                <span class="pill-label">${label}</span>
+                <span class="pill-value">${this.renderScoreValue(numeric)}</span>
+            </div>
+        `;
+    }
+
+    renderWineScoreSummary(wine, variant = 'card') {
+        const { overallScore, qualityScore, criticScore, weatherScore, hasScores } = this.getWineScoreData(wine);
+
+        if (!hasScores) {
+            return '';
+        }
+
+        const variantClass = variant ? ` ${variant}` : '';
+        const overallBase = overallScore ?? qualityScore ?? criticScore ?? weatherScore;
+        const overallLabel = variant === 'list' ? 'Score' : 'Overall Score';
+
+        const breakdownHtml = [
+            this.renderScorePill('Quality', qualityScore),
+            this.renderScorePill('Critic', criticScore),
+            this.renderScorePill('Weather', weatherScore)
+        ].filter(Boolean).join('');
+
+        const showBreakdown = breakdownHtml.trim().length > 0 && variant !== 'list';
+
+        return `
+            <div class="wine-score-summary${variantClass}">
+                <div class="score-chip overall">
+                    <span class="score-label">${overallLabel}</span>
+                    <span class="score-value">${this.renderScoreValue(overallBase)}</span>
+                </div>
+                ${showBreakdown ? `<div class="score-breakdown">${breakdownHtml}</div>` : ''}
+            </div>
+        `;
+    }
     
     // Action methods for wine cards
     reserveWineModal(vintageId, wineName) {
@@ -1907,23 +2084,57 @@ class SommOS {
 
     createCatalogWineCard(wine, viewType) {
         const displayRegion = this.getDisplayRegion(wine);
-        const totalValue = (wine.total_stock || 0) * (wine.cost_per_bottle || 0);
-        
+        const stock = this.parseNumeric(wine.total_stock) ?? 0;
+        const totalValueNumeric = this.parseNumeric(wine.total_value);
+        const avgCostNumeric = this.parseNumeric(wine.avg_cost_per_bottle ?? wine.cost_per_bottle);
+        const avgCost = avgCostNumeric !== null
+            ? avgCostNumeric
+            : (stock > 0 && totalValueNumeric !== null ? totalValueNumeric / stock : null);
+        const totalValue = totalValueNumeric !== null
+            ? totalValueNumeric
+            : (avgCost !== null ? avgCost * stock : 0);
+        const peakWindow = this.getPeakDrinkingWindow(wine);
+        const scoreVariant = viewType === 'list' ? 'list' : (viewType === 'detail' ? 'detail' : 'card');
+        const scoreSummary = this.renderWineScoreSummary(wine, scoreVariant);
+        const formattedStock = this.formatNumber(stock);
+        const formattedValue = this.formatCurrency(totalValue);
+        const formattedAvgCost = this.formatCurrency(avgCost, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+        const stockWithUnit = formattedStock === '—' ? '—' : `${formattedStock} bottles`;
+        const avgCostWithUnit = formattedAvgCost !== '—' ? `${formattedAvgCost} per bottle` : '—';
+
         if (viewType === 'grid') {
             return `
                 <div class="wine-card catalog-card" onclick="app.showWineDetails('${wine.id}')">
-                    <div class="wine-header">
+                    <div class="wine-card-header">
                         <div class="wine-type-badge ${wine.wine_type?.toLowerCase() || 'unknown'}">
                             ${this.getWineTypeIcon(wine.wine_type)} ${wine.wine_type || 'Wine'}
                         </div>
                         <div class="wine-year">${wine.year || 'N/A'}</div>
                     </div>
-                    <h3>${wine.name || 'Unknown Wine'}</h3>
-                    <p class="producer">${wine.producer || 'Unknown Producer'}</p>
-                    <p class="region">${displayRegion}</p>
+                    <div class="wine-card-body">
+                        <h3>${wine.name || 'Unknown Wine'}</h3>
+                        <p class="producer">${wine.producer || 'Unknown Producer'}</p>
+                        <div class="wine-meta">
+                            <span class="meta-item">${displayRegion}</span>
+                            ${peakWindow ? `<span class="meta-item">Peak: ${peakWindow}</span>` : ''}
+                        </div>
+                        ${scoreSummary || ''}
+                    </div>
                     <div class="wine-stats">
-                        <span class="stock">${wine.total_stock || 0} bottles</span>
-                        <span class="value">$${totalValue.toFixed(0)}</span>
+                        <div class="stat-block">
+                            <span class="stat-label">Stock</span>
+                            <span class="stat-value">${formattedStock}</span>
+                            <span class="stat-unit">bottles</span>
+                        </div>
+                        <div class="stat-block">
+                            <span class="stat-label">Avg Cost</span>
+                            <span class="stat-value">${formattedAvgCost}</span>
+                            ${formattedAvgCost !== '—' ? '<span class="stat-unit">per bottle</span>' : ''}
+                        </div>
+                        <div class="stat-block">
+                            <span class="stat-label">Value</span>
+                            <span class="stat-value">${formattedValue}</span>
+                        </div>
                     </div>
                 </div>
             `;
@@ -1938,10 +2149,18 @@ class SommOS {
                         <span class="type">${wine.wine_type || 'Wine'}</span>
                         <span class="year">${wine.year || 'N/A'}</span>
                         <span class="region">${displayRegion}</span>
+                        ${peakWindow ? `<span class="peak-window">Peak: ${peakWindow}</span>` : ''}
                     </div>
                     <div class="wine-metrics">
-                        <span class="stock">${wine.total_stock || 0} bottles</span>
-                        <span class="value">$${totalValue.toFixed(0)}</span>
+                        ${scoreSummary || ''}
+                        <div class="metric-line">
+                            <span class="metric-label">Stock</span>
+                            <span class="metric-value">${stockWithUnit}</span>
+                        </div>
+                        <div class="metric-line">
+                            <span class="metric-label">Value</span>
+                            <span class="metric-value">${formattedValue}</span>
+                        </div>
                     </div>
                 </div>
             `;
@@ -1960,16 +2179,18 @@ class SommOS {
                             <div class="wine-year-badge">${wine.year || 'N/A'}</div>
                         </div>
                     </div>
+                    ${scoreSummary || ''}
                     <div class="wine-detail-content">
                         <div class="wine-info">
                             <p><strong>Region:</strong> ${displayRegion}</p>
                             <p><strong>Alcohol:</strong> ${wine.alcohol_content || 'N/A'}%</p>
                             <p><strong>Style:</strong> ${wine.style || 'N/A'}</p>
+                            ${peakWindow ? `<p><strong>Peak Window:</strong> ${peakWindow}</p>` : ''}
                         </div>
                         <div class="wine-inventory">
-                            <p><strong>Total Stock:</strong> ${wine.total_stock || 0} bottles</p>
-                            <p><strong>Total Value:</strong> $${totalValue.toFixed(0)}</p>
-                            <p><strong>Avg. Cost:</strong> $${(wine.cost_per_bottle || 0).toFixed(2)}/bottle</p>
+                            <p><strong>Total Stock:</strong> ${stockWithUnit}</p>
+                            <p><strong>Inventory Value:</strong> ${formattedValue}</p>
+                            <p><strong>Avg. Cost:</strong> ${avgCostWithUnit}</p>
                         </div>
                     </div>
                     ${wine.tasting_notes ? `
@@ -1986,11 +2207,24 @@ class SommOS {
     updateCatalogStats(wines) {
         const totalCount = wines.length;
         const totalBottles = wines.reduce((sum, wine) => sum + (wine.total_stock || 0), 0);
-        const totalValue = wines.reduce((sum, wine) => sum + ((wine.total_stock || 0) * (wine.cost_per_bottle || 0)), 0);
-        
-        document.getElementById('catalog-count').textContent = totalCount.toLocaleString();
-        document.getElementById('catalog-bottles').textContent = totalBottles.toLocaleString();
-        document.getElementById('catalog-value').textContent = '$' + totalValue.toLocaleString();
+        const totalValue = wines.reduce((sum, wine) => {
+            const value = this.parseNumeric(wine.total_value);
+            if (value !== null) {
+                return sum + value;
+            }
+
+            const stock = wine.total_stock || 0;
+            const avgCost = this.parseNumeric(wine.avg_cost_per_bottle ?? wine.cost_per_bottle);
+            if (avgCost !== null) {
+                return sum + (stock * avgCost);
+            }
+
+            return sum;
+        }, 0);
+
+        document.getElementById('catalog-count').textContent = this.formatNumber(totalCount);
+        document.getElementById('catalog-bottles').textContent = this.formatNumber(totalBottles);
+        document.getElementById('catalog-value').textContent = this.formatCurrency(totalValue);
     }
 
     updateCatalogPagination(currentCount, limit) {
@@ -2046,7 +2280,31 @@ class SommOS {
         const displayRegion = this.getDisplayRegion(wine);
         const vintages = wine.vintages || [];
         const aliases = wine.aliases || [];
-        
+        const primaryVintage = vintages[0] || {};
+        const scoreContext = {
+            ...wine,
+            quality_score: wine.quality_score ?? primaryVintage.quality_score,
+            critic_score: wine.critic_score ?? primaryVintage.critic_score,
+            weather_score: wine.weather_score ?? primaryVintage.weather_score,
+            peak_drinking_start: wine.peak_drinking_start ?? primaryVintage.peak_drinking_start,
+            peak_drinking_end: wine.peak_drinking_end ?? primaryVintage.peak_drinking_end,
+            year: wine.year ?? primaryVintage.year
+        };
+
+        const scoreSummary = this.renderWineScoreSummary(scoreContext, 'modal');
+        const peakWindow = this.getPeakDrinkingWindow(scoreContext);
+        const stockFromWine = this.parseNumeric(wine.total_stock);
+        const totalStock = stockFromWine !== null ? stockFromWine : vintages.reduce((sum, vintage) => sum + (vintage.total_stock || 0), 0);
+        const valueFromWine = this.parseNumeric(wine.total_value);
+        const totalValue = valueFromWine !== null ? valueFromWine : vintages.reduce((sum, vintage) => sum + (this.parseNumeric(vintage.total_value) || 0), 0);
+        const avgCostFromWine = this.parseNumeric(wine.avg_cost_per_bottle);
+        const averageCost = avgCostFromWine !== null ? avgCostFromWine : (totalStock > 0 ? totalValue / totalStock : null);
+        const formattedStock = this.formatNumber(totalStock);
+        const stockWithUnit = formattedStock === '—' ? '—' : `${formattedStock} bottles`;
+        const formattedValue = this.formatCurrency(totalValue);
+        const formattedAvgCost = this.formatCurrency(averageCost, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+        const avgCostWithUnit = formattedAvgCost !== '—' ? `${formattedAvgCost} per bottle` : '—';
+
         this.ui.showModal(`Wine Details - ${wine.name}`, `
             <div class="wine-details-modal">
                 <div class="wine-details-header">
@@ -2061,7 +2319,9 @@ class SommOS {
                         </div>
                     </div>
                 </div>
-                
+
+                ${scoreSummary || ''}
+
                 <div class="wine-details-content">
                     <div class="wine-info-section">
                         <h4>Wine Information</h4>
@@ -2071,21 +2331,28 @@ class SommOS {
                             <div><strong>Alcohol:</strong> ${wine.alcohol_content || 'N/A'}%</div>
                             <div><strong>Style:</strong> ${wine.style || 'N/A'}</div>
                         </div>
-                        
+
+                        ${peakWindow ? `
+                            <div class="peak-window">
+                                <strong>Peak Drinking Window:</strong>
+                                <p>${peakWindow}</p>
+                            </div>
+                        ` : ''}
+
                         ${wine.grape_varieties ? `
                             <div class="grape-varieties">
                                 <strong>Grape Varieties:</strong>
                                 <p>${Array.isArray(wine.grape_varieties) ? wine.grape_varieties.join(', ') : wine.grape_varieties}</p>
                             </div>
                         ` : ''}
-                        
+
                         ${wine.tasting_notes ? `
                             <div class="tasting-notes">
                                 <strong>Tasting Notes:</strong>
                                 <p>${wine.tasting_notes}</p>
                             </div>
                         ` : ''}
-                        
+
                         ${wine.food_pairings ? `
                             <div class="food-pairings">
                                 <strong>Food Pairings:</strong>
@@ -2093,17 +2360,45 @@ class SommOS {
                             </div>
                         ` : ''}
                     </div>
-                    
+
+                    <div class="wine-inventory">
+                        <h4>Cellar Snapshot</h4>
+                        <div class="inventory-summary">
+                            <div class="inventory-metric">
+                                <span class="metric-label">Total Stock</span>
+                                <span class="metric-value">${stockWithUnit}</span>
+                            </div>
+                            <div class="inventory-metric">
+                                <span class="metric-label">Inventory Value</span>
+                                <span class="metric-value">${formattedValue}</span>
+                            </div>
+                            <div class="inventory-metric">
+                                <span class="metric-label">Average Cost</span>
+                                <span class="metric-value">${avgCostWithUnit}</span>
+                            </div>
+                        </div>
+                    </div>
+
                     ${vintages.length > 0 ? `
                         <div class="vintages-section">
                             <h4>Available Vintages</h4>
                             <div class="vintages-list">
                                 ${vintages.map(vintage => `
                                     <div class="vintage-item">
-                                        <div class="vintage-year">${vintage.year}</div>
-                                        <div class="vintage-stock">${vintage.total_stock || 0} bottles</div>
-                                        <div class="vintage-quality">
-                                            ${vintage.quality_score ? `Quality: ${vintage.quality_score}/100` : ''}
+                                        <div class="vintage-header">
+                                            <div class="vintage-year">${vintage.year}</div>
+                                            <div class="vintage-stock">${this.formatNumber(vintage.total_stock || 0)} bottles</div>
+                                        </div>
+                                        <div class="vintage-metrics">
+                                            ${this.renderScorePill('Quality', vintage.quality_score) || '<div class="score-pill muted"><span class="pill-label">Quality</span><span class="pill-value">—</span></div>'}
+                                            ${(() => {
+                                                const avg = this.formatCurrency(vintage.avg_cost_per_bottle, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+                                                return avg !== '—' ? `<span class="metric">Avg Cost: ${avg}</span>` : '';
+                                            })()}
+                                            ${(() => {
+                                                const value = this.formatCurrency(vintage.total_value);
+                                                return value !== '—' ? `<span class="metric">Value: ${value}</span>` : '';
+                                            })()}
                                         </div>
                                         <div class="vintage-actions">
                                             <button class="btn-small primary" onclick="app.reserveWineModal('${vintage.id}', '${wine.name} ${vintage.year}')">
@@ -2115,7 +2410,7 @@ class SommOS {
                             </div>
                         </div>
                     ` : ''}
-                    
+
                     ${aliases.length > 0 ? `
                         <div class="aliases-section">
                             <h4>Known As</h4>
@@ -2125,7 +2420,7 @@ class SommOS {
                         </div>
                     ` : ''}
                 </div>
-                
+
                 <div class="wine-details-actions">
                     <button class="btn secondary" onclick="app.ui.hideModal()">Close</button>
                     <button class="btn primary" onclick="app.navigateToView('pairing'); app.ui.hideModal();">Find Pairings</button>


### PR DESCRIPTION
## Summary
- surface average cost, valuation, and scoring fields through the wine catalog API responses
- refresh the catalog cards, list rows, and detail modal to highlight score breakdowns and inventory metrics
- add styling for the new score summary widgets, peak window badges, and inventory metric layouts

## Testing
- `npm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68d5aa68a620832b9ae4fd4f61187108