### PR TITLE
Add dashboard score explanation section

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -458,6 +458,91 @@ select:focus {
     border-color: var(--accent-color);
 }
 
+.score-insights {
+    position: relative;
+}
+
+.score-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem;
+}
+
+.score-card {
+    background: var(--gradient-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius-large);
+    padding: 1.75rem;
+    display: flex;
+    gap: 1.25rem;
+    box-shadow: 0 16px 40px rgba(4, 10, 24, 0.4);
+    transition: transform var(--transition-medium), box-shadow var(--transition-medium), border-color var(--transition-medium);
+}
+
+.score-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 22px 55px rgba(6, 12, 28, 0.55);
+    border-color: rgba(156, 124, 255, 0.45);
+}
+
+.score-icon {
+    font-size: 2.5rem;
+    line-height: 1;
+    filter: drop-shadow(0 0 8px rgba(156, 124, 255, 0.35));
+}
+
+.score-content h3 {
+    font-size: 1.2rem;
+    margin-bottom: 0.65rem;
+    color: var(--gold-color);
+}
+
+.score-content p {
+    color: var(--text-secondary);
+    margin-bottom: 0.85rem;
+    font-size: 0.95rem;
+}
+
+.score-factors {
+    list-style: none;
+    display: grid;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+}
+
+.score-factors li {
+    background: rgba(8, 15, 31, 0.45);
+    border-radius: var(--border-radius-small);
+    padding: 0.65rem 0.75rem;
+    border: 1px solid rgba(156, 124, 255, 0.08);
+}
+
+.score-factors strong {
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+@media (max-width: 1200px) {
+    .score-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 768px) {
+    .score-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .score-card {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .score-icon {
+        font-size: 2.1rem;
+    }
+}
+
 .btn-icon {
     margin-right: 0.75rem;
     font-size: 1.25rem;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -137,24 +137,68 @@
                 </div>
                 
                 <div class="dashboard-sections">
-                    <section class="dashboard-section">
-                        <h2>Quick Actions</h2>
-                        <div class="quick-actions">
-                            <button class="action-btn primary" data-action="quick-pairing">
-                                <span class="btn-icon">⚡</span>
-                                Quick Pairing
-                            </button>
-                            <button class="action-btn" data-action="record-consumption">
-                                <span class="btn-icon">📝</span>
-                                Record Service
-                            </button>
-                            <button class="action-btn" data-action="check-stock">
-                                <span class="btn-icon">📊</span>
-                                Check Stock
-                            </button>
-                        </div>
-                    </section>
-                    
+                <section class="dashboard-section">
+                    <h2>Quick Actions</h2>
+                    <div class="quick-actions">
+                        <button class="action-btn primary" data-action="quick-pairing">
+                            <span class="btn-icon">⚡</span>
+                            Quick Pairing
+                        </button>
+                        <button class="action-btn" data-action="record-consumption">
+                            <span class="btn-icon">📝</span>
+                            Record Service
+                        </button>
+                        <button class="action-btn" data-action="check-stock">
+                            <span class="btn-icon">📊</span>
+                            Check Stock
+                        </button>
+                    </div>
+                </section>
+
+                <section class="dashboard-section score-insights">
+                    <h2>Understanding SommOS Scores</h2>
+                    <div class="score-grid">
+                        <article class="score-card">
+                            <div class="score-icon" aria-hidden="true">🎯</div>
+                            <div class="score-content">
+                                <h3>Pairing Confidence</h3>
+                                <p>Displayed in pairing recommendations, this percentage blends multiple pairing heuristics to show how certain SommOS is that a wine complements your dish.</p>
+                                <ul class="score-factors">
+                                    <li><strong>Flavor Harmony:</strong> Analyzes the match between tasting notes in your dish description and the wine&rsquo;s profile.</li>
+                                    <li><strong>Structure Balance:</strong> Considers acidity, tannin, and body so richer dishes lean toward fuller wines.</li>
+                                    <li><strong>Service Readiness:</strong> Gives a boost when bottles are in stock and at optimal serving temperature or aging window.</li>
+                                </ul>
+                            </div>
+                        </article>
+
+                        <article class="score-card">
+                            <div class="score-icon" aria-hidden="true">💼</div>
+                            <div class="score-content">
+                                <h3>Procurement Opportunity</h3>
+                                <p>Used on the procurement tab, this score highlights the smartest restocking moves by weighing potential value against urgency.</p>
+                                <ul class="score-factors">
+                                    <li><strong>Inventory Gap:</strong> Prioritizes wines that fill shortages or complement upcoming service plans.</li>
+                                    <li><strong>Supplier Signal:</strong> Accounts for supplier reliability, available allocations, and delivery windows.</li>
+                                    <li><strong>Cost Efficiency:</strong> Rewards offers that achieve better price-to-value or long-term appreciation.</li>
+                                </ul>
+                            </div>
+                        </article>
+
+                        <article class="score-card">
+                            <div class="score-icon" aria-hidden="true">🏅</div>
+                            <div class="score-content">
+                                <h3>Vintage Quality</h3>
+                                <p>Shown for cellared bottles, the 0&ndash;100 rating blends critic consensus with SommOS aging models to track drinking windows.</p>
+                                <ul class="score-factors">
+                                    <li><strong>Critical Reviews:</strong> Aggregates trusted publications and competitions for the vintage.</li>
+                                    <li><strong>Aging Potential:</strong> Evaluates grape variety, region, and storage history to estimate peak maturity.</li>
+                                    <li><strong>Cellar Readiness:</strong> Adjusts for bottle condition and serving notes entered by your crew.</li>
+                                </ul>
+                            </div>
+                        </article>
+                    </div>
+                </section>
+
                 <section class="dashboard-section">
                     <h2>Wine Collection Analytics</h2>
                     <div class="charts-container">


### PR DESCRIPTION
## Summary
- add an "Understanding SommOS Scores" section on the dashboard to explain pairing, procurement, and vintage scoring heuristics
- style the new score insight cards to match existing dashboard visuals and stay responsive on smaller screens

## Testing
- `npm test -- --passWithNoTests` *(fails: existing Jest configuration enforces coverage thresholds that are currently unmet in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d5afea9008832b92b45c2ca860e93e