### PR TITLE
Add system activity endpoint and expand intake test coverage

### DIFF
--- a/backend/core/__mocks__/inventory_manager.js
+++ b/backend/core/__mocks__/inventory_manager.js
@@ -90,6 +90,33 @@ class InventoryManager {
         };
     }
 
+    async createInventoryIntake(request = {}) {
+        return {
+            success: true,
+            intake_id: 101,
+            status: 'ORDERED',
+            items: request.items || [],
+            outstanding_quantity: (request.items || []).reduce((sum, item) => sum + (item.stock?.quantity || 0), 0)
+        };
+    }
+
+    async receiveInventoryIntake(intakeId, receipts = []) {
+        return {
+            success: true,
+            intake_id: intakeId,
+            received_count: receipts.length,
+            status: 'RECEIVED'
+        };
+    }
+
+    async getInventoryIntakeStatus(intakeId) {
+        return {
+            intake_id: intakeId,
+            all_received: true,
+            outstanding_bottles: 0
+        };
+    }
+
     async moveWine(vintageId, fromLocation, toLocation, quantity) {
         return {
             success: true,


### PR DESCRIPTION
## Summary
- add a /api/system/activity endpoint that surfaces recent ledger activity for the dashboard
- extend backend mocks to support intake workflows and richer ledger fixtures
- expand backend API tests to cover system activity and intake endpoints, raising coverage thresholds

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5b360be7c832b915936781dfb454c