### PR TITLE
Improve API client environment detection and query handling

### DIFF
--- a/tests/frontend/frontend.test.js
+++ b/tests/frontend/frontend.test.js
@@ -237,8 +237,23 @@ describe('SommOS Frontend', () => {
 
             const result = await api.getInventory();
 
-            expect(global.fetch).toHaveBeenCalledWith('http://localhost:3000/api/inventory/stock?', expect.any(Object));
+            expect(global.fetch).toHaveBeenCalledWith('http://localhost:3000/api/inventory/stock', expect.any(Object));
             expect(result).toEqual({ success: true, data: [] });
+        });
+
+        test('should omit empty filter values when building query string', async () => {
+            const mockResponse = {
+                ok: true,
+                json: async () => ({ success: true, data: [] })
+            };
+            global.fetch.mockResolvedValue(mockResponse);
+
+            await api.getInventory({ location: '', wine_type: undefined, region: 'Bordeaux' });
+
+            expect(global.fetch).toHaveBeenCalledWith(
+                'http://localhost:3000/api/inventory/stock?region=Bordeaux',
+                expect.any(Object)
+            );
         });
 
         test('should handle API request with filters', async () => {


### PR DESCRIPTION
## Summary
- guard SommOS API base URL detection when window.location is unavailable and fall back to a sensible default
- normalize inventory query construction to drop empty filter values and avoid trailing question marks
- extend frontend API tests to cover the new query building behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5c3cb8510832bbfb7060bb751a79a