### PR TITLE
Add OpenAPI specification for SommOS API

### DIFF
--- a/backend/api/openapi.yaml
+++ b/backend/api/openapi.yaml
@@ -1,0 +1,1272 @@
+openapi: 3.0.3
+info:
+  title: SommOS API
+  version: 1.0.0
+  description: |
+    Canonical contract for the SommOS yacht wine management platform. All
+    endpoints are prefixed with `/api` and return JSON payloads.
+servers:
+  - url: /api
+    description: Internal Express server base path
+components:
+  schemas:
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          description: Stable machine-readable error identifier.
+        message:
+          type: string
+          description: Human friendly explanation of the error.
+        details:
+          description: Optional structured error context.
+          oneOf:
+            - type: string
+            - type: object
+            - type: array
+    ErrorResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          $ref: '#/components/schemas/Error'
+    Pagination:
+      type: object
+      properties:
+        total:
+          type: integer
+          minimum: 0
+        limit:
+          type: integer
+          minimum: 0
+        offset:
+          type: integer
+          minimum: 0
+    PairingRecommendation:
+      type: object
+      properties:
+        wine:
+          type: object
+          description: Wine record selected for the pairing.
+          additionalProperties: true
+        score:
+          type: object
+          description: Detailed scoring metrics.
+          additionalProperties:
+            type: number
+        reasoning:
+          type: string
+        ai_enhanced:
+          type: boolean
+        learning_session_id:
+          type: string
+        learning_recommendation_id:
+          type: string
+    QuickPairing:
+      type: object
+      properties:
+        wine:
+          type: object
+          additionalProperties: true
+        reasoning:
+          type: string
+        confidence:
+          type: number
+    InventoryRecord:
+      type: object
+      description: Inventory item enriched with guidance metadata.
+      additionalProperties: true
+    InventoryLedgerEntry:
+      type: object
+      additionalProperties: true
+    IntakeReceipt:
+      type: object
+      additionalProperties: true
+    ProcurementOpportunity:
+      type: object
+      additionalProperties: true
+    ProcurementOrder:
+      type: object
+      additionalProperties: true
+    Wine:
+      type: object
+      additionalProperties: true
+    VintageAnalysis:
+      type: object
+      additionalProperties: true
+    ActivityEvent:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        title:
+          type: string
+        details:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+paths:
+  /pairing/recommend:
+    post:
+      tags: [Pairing]
+      summary: Generate wine pairing recommendations.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [dish]
+              properties:
+                dish:
+                  description: Dish description or structured context.
+                  oneOf:
+                    - type: string
+                    - type: object
+                      additionalProperties: true
+                context:
+                  type: object
+                  additionalProperties: true
+                guestPreferences:
+                  type: object
+                  additionalProperties: true
+                options:
+                  type: object
+                  additionalProperties: true
+      responses:
+        '200':
+          description: Successful pairing recommendations.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PairingRecommendation'
+                  meta:
+                    type: object
+                    properties:
+                      learning_session_id:
+                        type: string
+        '400':
+          description: Missing required information.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Pairing generation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /pairing/quick:
+    post:
+      tags: [Pairing]
+      summary: Request expedited pairing suggestions.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                dish:
+                  description: Dish description or structure.
+                  oneOf:
+                    - type: string
+                    - type: object
+                      additionalProperties: true
+                context:
+                  type: object
+                  additionalProperties: true
+                ownerLikes:
+                  type: object
+                  additionalProperties: true
+      responses:
+        '200':
+          description: Quick pairing results.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/QuickPairing'
+        '500':
+          description: Unable to produce quick pairings.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /pairing/feedback:
+    post:
+      tags: [Pairing]
+      summary: Record feedback for a pairing recommendation.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [recommendation_id, rating]
+              properties:
+                recommendation_id:
+                  type: string
+                rating:
+                  type: number
+                notes:
+                  type: string
+                selected:
+                  type: boolean
+      responses:
+        '200':
+          description: Feedback successfully captured.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  message:
+                    type: string
+        '400':
+          description: Missing required identifiers.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to record feedback.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory:
+    get:
+      tags: [Inventory]
+      summary: Retrieve a paginated list of inventory items.
+      parameters:
+        - in: query
+          name: location
+          schema:
+            type: string
+        - in: query
+          name: wine_type
+          schema:
+            type: string
+        - in: query
+          name: region
+          schema:
+            type: string
+        - in: query
+          name: available_only
+          schema:
+            type: boolean
+        - in: query
+          name: limit
+          schema:
+            type: integer
+        - in: query
+          name: offset
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Inventory listing.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/InventoryRecord'
+                  meta:
+                    $ref: '#/components/schemas/Pagination'
+        '500':
+          description: Failed to load inventory.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/stock:
+    get:
+      tags: [Inventory]
+      summary: Retrieve current stock levels.
+      parameters:
+        - in: query
+          name: location
+          schema:
+            type: string
+        - in: query
+          name: wine_type
+          schema:
+            type: string
+        - in: query
+          name: region
+          schema:
+            type: string
+        - in: query
+          name: available_only
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Stock information.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '500':
+          description: Failed to retrieve stock information.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/{id}:
+    get:
+      tags: [Inventory]
+      summary: Fetch a specific inventory record.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Inventory record.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    $ref: '#/components/schemas/InventoryRecord'
+        '404':
+          description: Inventory item not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to load inventory item.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /locations:
+    get:
+      tags: [Inventory]
+      summary: List storage locations.
+      responses:
+        '200':
+          description: Available locations.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      type: string
+        '500':
+          description: Unable to load locations.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/consume:
+    post:
+      tags: [Inventory]
+      summary: Record wine consumption.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [vintage_id, location, quantity]
+              properties:
+                vintage_id:
+                  type: integer
+                location:
+                  type: string
+                quantity:
+                  type: number
+                notes:
+                  type: string
+                created_by:
+                  type: string
+      responses:
+        '200':
+          description: Consumption recorded.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Missing required fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to record consumption.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/receive:
+    post:
+      tags: [Inventory]
+      summary: Record incoming wine.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [vintage_id, location, quantity]
+              properties:
+                vintage_id:
+                  type: integer
+                location:
+                  type: string
+                quantity:
+                  type: number
+                unit_cost:
+                  type: number
+                reference_id:
+                  type: string
+                notes:
+                  type: string
+                created_by:
+                  type: string
+      responses:
+        '200':
+          description: Receipt recorded.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Missing required fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to record receipt.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/intake:
+    post:
+      tags: [Inventory]
+      summary: Create an intake order.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '200':
+          description: Intake order created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Invalid intake request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Intake creation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/intake/{intakeId}/receive:
+    post:
+      tags: [Inventory]
+      summary: Mark items as received for an intake order.
+      parameters:
+        - in: path
+          name: intakeId
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [receipts]
+              properties:
+                receipts:
+                  type: array
+                  minItems: 1
+                  items:
+                    $ref: '#/components/schemas/IntakeReceipt'
+                created_by:
+                  type: string
+                notes:
+                  type: string
+      responses:
+        '200':
+          description: Intake receipt processed.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Invalid receipt payload.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to process receipts.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/intake/{intakeId}/status:
+    get:
+      tags: [Inventory]
+      summary: Retrieve intake completion status.
+      parameters:
+        - in: path
+          name: intakeId
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Intake status information.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '404':
+          description: Intake not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to load intake status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/move:
+    post:
+      tags: [Inventory]
+      summary: Move wine between locations.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [vintage_id, from_location, to_location, quantity]
+              properties:
+                vintage_id:
+                  type: integer
+                from_location:
+                  type: string
+                to_location:
+                  type: string
+                quantity:
+                  type: number
+                notes:
+                  type: string
+                created_by:
+                  type: string
+      responses:
+        '200':
+          description: Movement recorded.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Missing required fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to record movement.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/reserve:
+    post:
+      tags: [Inventory]
+      summary: Reserve wine for future service.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [vintage_id, location, quantity]
+              properties:
+                vintage_id:
+                  type: integer
+                location:
+                  type: string
+                quantity:
+                  type: number
+                notes:
+                  type: string
+                created_by:
+                  type: string
+      responses:
+        '200':
+          description: Reservation recorded.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Missing required fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to reserve inventory.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/ledger/{vintage_id}:
+    get:
+      tags: [Inventory]
+      summary: Retrieve ledger history for a vintage.
+      parameters:
+        - in: path
+          name: vintage_id
+          required: true
+          schema:
+            type: integer
+        - in: query
+          name: limit
+          schema:
+            type: integer
+        - in: query
+          name: offset
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Ledger entries.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/InventoryLedgerEntry'
+        '500':
+          description: Unable to load ledger history.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /procurement/opportunities:
+    get:
+      tags: [Procurement]
+      summary: Analyze procurement opportunities.
+      parameters:
+        - in: query
+          name: region
+          schema:
+            type: string
+        - in: query
+          name: regions
+          schema:
+            type: string
+            description: Comma-delimited region list.
+        - in: query
+          name: wine_type
+          schema:
+            type: string
+        - in: query
+          name: wine_types
+          schema:
+            type: string
+            description: Comma-delimited wine type list.
+        - in: query
+          name: max_price
+          schema:
+            type: number
+        - in: query
+          name: min_score
+          schema:
+            type: integer
+        - in: query
+          name: budget
+          schema:
+            type: number
+      responses:
+        '200':
+          description: Procurement opportunities.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ProcurementOpportunity'
+        '500':
+          description: Unable to analyze procurement opportunities.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /procurement/analyze:
+    post:
+      tags: [Procurement]
+      summary: Analyze a specific procurement decision.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [vintage_id, supplier_id]
+              properties:
+                vintage_id:
+                  type: integer
+                supplier_id:
+                  type: integer
+                quantity:
+                  type: integer
+                context:
+                  type: object
+                  additionalProperties: true
+      responses:
+        '200':
+          description: Procurement analysis.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Missing required fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to analyze procurement decision.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /procurement/order:
+    post:
+      tags: [Procurement]
+      summary: Generate a purchase order.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [items, supplier_id]
+              properties:
+                items:
+                  type: array
+                  minItems: 1
+                  items:
+                    type: object
+                    additionalProperties: true
+                supplier_id:
+                  type: integer
+                delivery_date:
+                  type: string
+                  format: date
+                notes:
+                  type: string
+      responses:
+        '200':
+          description: Purchase order details.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    $ref: '#/components/schemas/ProcurementOrder'
+        '400':
+          description: Missing required fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to generate purchase order.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /wines:
+    get:
+      tags: [Wines]
+      summary: Retrieve wines with optional filters.
+      parameters:
+        - in: query
+          name: region
+          schema:
+            type: string
+        - in: query
+          name: wine_type
+          schema:
+            type: string
+        - in: query
+          name: producer
+          schema:
+            type: string
+        - in: query
+          name: search
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            type: integer
+        - in: query
+          name: offset
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Wine catalog.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Wine'
+        '500':
+          description: Unable to load wines.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags: [Wines]
+      summary: Add a new wine with vintage intelligence.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [wine, vintage, stock]
+              properties:
+                wine:
+                  type: object
+                  additionalProperties: true
+                vintage:
+                  type: object
+                  additionalProperties: true
+                stock:
+                  type: object
+                  additionalProperties: true
+      responses:
+        '201':
+          description: Wine added to inventory.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    $ref: '#/components/schemas/Wine'
+                  message:
+                    type: string
+        '400':
+          description: Missing required sections.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to add wine.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /wines/{id}:
+    get:
+      tags: [Wines]
+      summary: Retrieve a wine with detailed vintages and aliases.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Wine record with enrichments.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    $ref: '#/components/schemas/Wine'
+        '404':
+          description: Wine not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to load wine details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /vintage/analysis/{wine_id}:
+    get:
+      tags: [Vintage Intelligence]
+      summary: Retrieve analysis for a wine.
+      parameters:
+        - in: path
+          name: wine_id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Vintage analysis.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    $ref: '#/components/schemas/VintageAnalysis'
+        '404':
+          description: Wine not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to load analysis.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /vintage/procurement-recommendations:
+    get:
+      tags: [Vintage Intelligence]
+      summary: Retrieve procurement recommendations based on inventory gaps.
+      responses:
+        '200':
+          description: Procurement recommendations.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
+        '500':
+          description: Unable to load recommendations.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /vintage/batch-enrich:
+    post:
+      tags: [Vintage Intelligence]
+      summary: Batch enrich wines with vintage intelligence.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                filters:
+                  type: object
+                  additionalProperties: true
+                limit:
+                  type: integer
+      responses:
+        '200':
+          description: Batch enrichment results.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
+        '500':
+          description: Unable to perform batch enrichment.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /vintage/pairing-insight:
+    post:
+      tags: [Vintage Intelligence]
+      summary: Generate weather-based pairing insights for a wine and dish context.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [wine_id, dish_context]
+              properties:
+                wine_id:
+                  type: integer
+                dish_context:
+                  type: object
+                  additionalProperties: true
+      responses:
+        '200':
+          description: Pairing insight generated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Missing required fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Wine not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to generate pairing insight.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /system/health:
+    get:
+      tags: [System]
+      summary: Application health check.
+      responses:
+        '200':
+          description: System is healthy.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  status:
+                    type: string
+                  timestamp:
+                    type: string
+                    format: date-time
+                  data:
+                    type: object
+                    additionalProperties: true
+        '500':
+          description: System health degraded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /system/activity:
+    get:
+      tags: [System]
+      summary: Retrieve recent system activity.
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Activity events.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ActivityEvent'
+        '500':
+          description: Unable to load activity feed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'


### PR DESCRIPTION
## Summary
- document the entire Express API surface in a new backend/api/openapi.yaml contract
- capture request parameters, response envelopes, and shared schemas for errors, inventory, pairing, procurement, and system routes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daa8db59a0832b997a90dc56866416