### PR TITLE
Add Zod-powered request validation middleware

### DIFF
--- a/backend/api/openapi.yaml
+++ b/backend/api/openapi.yaml
@@ -1,0 +1,1272 @@
+openapi: 3.0.3
+info:
+  title: SommOS API
+  version: 1.0.0
+  description: |
+    Canonical contract for the SommOS yacht wine management platform. All
+    endpoints are prefixed with `/api` and return JSON payloads.
+servers:
+  - url: /api
+    description: Internal Express server base path
+components:
+  schemas:
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          description: Stable machine-readable error identifier.
+        message:
+          type: string
+          description: Human friendly explanation of the error.
+        details:
+          description: Optional structured error context.
+          oneOf:
+            - type: string
+            - type: object
+            - type: array
+    ErrorResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          $ref: '#/components/schemas/Error'
+    Pagination:
+      type: object
+      properties:
+        total:
+          type: integer
+          minimum: 0
+        limit:
+          type: integer
+          minimum: 0
+        offset:
+          type: integer
+          minimum: 0
+    PairingRecommendation:
+      type: object
+      properties:
+        wine:
+          type: object
+          description: Wine record selected for the pairing.
+          additionalProperties: true
+        score:
+          type: object
+          description: Detailed scoring metrics.
+          additionalProperties:
+            type: number
+        reasoning:
+          type: string
+        ai_enhanced:
+          type: boolean
+        learning_session_id:
+          type: string
+        learning_recommendation_id:
+          type: string
+    QuickPairing:
+      type: object
+      properties:
+        wine:
+          type: object
+          additionalProperties: true
+        reasoning:
+          type: string
+        confidence:
+          type: number
+    InventoryRecord:
+      type: object
+      description: Inventory item enriched with guidance metadata.
+      additionalProperties: true
+    InventoryLedgerEntry:
+      type: object
+      additionalProperties: true
+    IntakeReceipt:
+      type: object
+      additionalProperties: true
+    ProcurementOpportunity:
+      type: object
+      additionalProperties: true
+    ProcurementOrder:
+      type: object
+      additionalProperties: true
+    Wine:
+      type: object
+      additionalProperties: true
+    VintageAnalysis:
+      type: object
+      additionalProperties: true
+    ActivityEvent:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        title:
+          type: string
+        details:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+paths:
+  /pairing/recommend:
+    post:
+      tags: [Pairing]
+      summary: Generate wine pairing recommendations.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [dish]
+              properties:
+                dish:
+                  description: Dish description or structured context.
+                  oneOf:
+                    - type: string
+                    - type: object
+                      additionalProperties: true
+                context:
+                  type: object
+                  additionalProperties: true
+                guestPreferences:
+                  type: object
+                  additionalProperties: true
+                options:
+                  type: object
+                  additionalProperties: true
+      responses:
+        '200':
+          description: Successful pairing recommendations.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PairingRecommendation'
+                  meta:
+                    type: object
+                    properties:
+                      learning_session_id:
+                        type: string
+        '400':
+          description: Missing required information.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Pairing generation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /pairing/quick:
+    post:
+      tags: [Pairing]
+      summary: Request expedited pairing suggestions.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                dish:
+                  description: Dish description or structure.
+                  oneOf:
+                    - type: string
+                    - type: object
+                      additionalProperties: true
+                context:
+                  type: object
+                  additionalProperties: true
+                ownerLikes:
+                  type: object
+                  additionalProperties: true
+      responses:
+        '200':
+          description: Quick pairing results.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/QuickPairing'
+        '500':
+          description: Unable to produce quick pairings.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /pairing/feedback:
+    post:
+      tags: [Pairing]
+      summary: Record feedback for a pairing recommendation.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [recommendation_id, rating]
+              properties:
+                recommendation_id:
+                  type: string
+                rating:
+                  type: number
+                notes:
+                  type: string
+                selected:
+                  type: boolean
+      responses:
+        '200':
+          description: Feedback successfully captured.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  message:
+                    type: string
+        '400':
+          description: Missing required identifiers.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to record feedback.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory:
+    get:
+      tags: [Inventory]
+      summary: Retrieve a paginated list of inventory items.
+      parameters:
+        - in: query
+          name: location
+          schema:
+            type: string
+        - in: query
+          name: wine_type
+          schema:
+            type: string
+        - in: query
+          name: region
+          schema:
+            type: string
+        - in: query
+          name: available_only
+          schema:
+            type: boolean
+        - in: query
+          name: limit
+          schema:
+            type: integer
+        - in: query
+          name: offset
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Inventory listing.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/InventoryRecord'
+                  meta:
+                    $ref: '#/components/schemas/Pagination'
+        '500':
+          description: Failed to load inventory.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/stock:
+    get:
+      tags: [Inventory]
+      summary: Retrieve current stock levels.
+      parameters:
+        - in: query
+          name: location
+          schema:
+            type: string
+        - in: query
+          name: wine_type
+          schema:
+            type: string
+        - in: query
+          name: region
+          schema:
+            type: string
+        - in: query
+          name: available_only
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Stock information.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '500':
+          description: Failed to retrieve stock information.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/{id}:
+    get:
+      tags: [Inventory]
+      summary: Fetch a specific inventory record.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Inventory record.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    $ref: '#/components/schemas/InventoryRecord'
+        '404':
+          description: Inventory item not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to load inventory item.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /locations:
+    get:
+      tags: [Inventory]
+      summary: List storage locations.
+      responses:
+        '200':
+          description: Available locations.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      type: string
+        '500':
+          description: Unable to load locations.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/consume:
+    post:
+      tags: [Inventory]
+      summary: Record wine consumption.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [vintage_id, location, quantity]
+              properties:
+                vintage_id:
+                  type: integer
+                location:
+                  type: string
+                quantity:
+                  type: number
+                notes:
+                  type: string
+                created_by:
+                  type: string
+      responses:
+        '200':
+          description: Consumption recorded.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Missing required fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to record consumption.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/receive:
+    post:
+      tags: [Inventory]
+      summary: Record incoming wine.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [vintage_id, location, quantity]
+              properties:
+                vintage_id:
+                  type: integer
+                location:
+                  type: string
+                quantity:
+                  type: number
+                unit_cost:
+                  type: number
+                reference_id:
+                  type: string
+                notes:
+                  type: string
+                created_by:
+                  type: string
+      responses:
+        '200':
+          description: Receipt recorded.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Missing required fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to record receipt.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/intake:
+    post:
+      tags: [Inventory]
+      summary: Create an intake order.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '200':
+          description: Intake order created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Invalid intake request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Intake creation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/intake/{intakeId}/receive:
+    post:
+      tags: [Inventory]
+      summary: Mark items as received for an intake order.
+      parameters:
+        - in: path
+          name: intakeId
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [receipts]
+              properties:
+                receipts:
+                  type: array
+                  minItems: 1
+                  items:
+                    $ref: '#/components/schemas/IntakeReceipt'
+                created_by:
+                  type: string
+                notes:
+                  type: string
+      responses:
+        '200':
+          description: Intake receipt processed.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Invalid receipt payload.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to process receipts.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/intake/{intakeId}/status:
+    get:
+      tags: [Inventory]
+      summary: Retrieve intake completion status.
+      parameters:
+        - in: path
+          name: intakeId
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Intake status information.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '404':
+          description: Intake not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to load intake status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/move:
+    post:
+      tags: [Inventory]
+      summary: Move wine between locations.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [vintage_id, from_location, to_location, quantity]
+              properties:
+                vintage_id:
+                  type: integer
+                from_location:
+                  type: string
+                to_location:
+                  type: string
+                quantity:
+                  type: number
+                notes:
+                  type: string
+                created_by:
+                  type: string
+      responses:
+        '200':
+          description: Movement recorded.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Missing required fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to record movement.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/reserve:
+    post:
+      tags: [Inventory]
+      summary: Reserve wine for future service.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [vintage_id, location, quantity]
+              properties:
+                vintage_id:
+                  type: integer
+                location:
+                  type: string
+                quantity:
+                  type: number
+                notes:
+                  type: string
+                created_by:
+                  type: string
+      responses:
+        '200':
+          description: Reservation recorded.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Missing required fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to reserve inventory.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /inventory/ledger/{vintage_id}:
+    get:
+      tags: [Inventory]
+      summary: Retrieve ledger history for a vintage.
+      parameters:
+        - in: path
+          name: vintage_id
+          required: true
+          schema:
+            type: integer
+        - in: query
+          name: limit
+          schema:
+            type: integer
+        - in: query
+          name: offset
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Ledger entries.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/InventoryLedgerEntry'
+        '500':
+          description: Unable to load ledger history.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /procurement/opportunities:
+    get:
+      tags: [Procurement]
+      summary: Analyze procurement opportunities.
+      parameters:
+        - in: query
+          name: region
+          schema:
+            type: string
+        - in: query
+          name: regions
+          schema:
+            type: string
+            description: Comma-delimited region list.
+        - in: query
+          name: wine_type
+          schema:
+            type: string
+        - in: query
+          name: wine_types
+          schema:
+            type: string
+            description: Comma-delimited wine type list.
+        - in: query
+          name: max_price
+          schema:
+            type: number
+        - in: query
+          name: min_score
+          schema:
+            type: integer
+        - in: query
+          name: budget
+          schema:
+            type: number
+      responses:
+        '200':
+          description: Procurement opportunities.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ProcurementOpportunity'
+        '500':
+          description: Unable to analyze procurement opportunities.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /procurement/analyze:
+    post:
+      tags: [Procurement]
+      summary: Analyze a specific procurement decision.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [vintage_id, supplier_id]
+              properties:
+                vintage_id:
+                  type: integer
+                supplier_id:
+                  type: integer
+                quantity:
+                  type: integer
+                context:
+                  type: object
+                  additionalProperties: true
+      responses:
+        '200':
+          description: Procurement analysis.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Missing required fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to analyze procurement decision.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /procurement/order:
+    post:
+      tags: [Procurement]
+      summary: Generate a purchase order.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [items, supplier_id]
+              properties:
+                items:
+                  type: array
+                  minItems: 1
+                  items:
+                    type: object
+                    additionalProperties: true
+                supplier_id:
+                  type: integer
+                delivery_date:
+                  type: string
+                  format: date
+                notes:
+                  type: string
+      responses:
+        '200':
+          description: Purchase order details.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    $ref: '#/components/schemas/ProcurementOrder'
+        '400':
+          description: Missing required fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to generate purchase order.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /wines:
+    get:
+      tags: [Wines]
+      summary: Retrieve wines with optional filters.
+      parameters:
+        - in: query
+          name: region
+          schema:
+            type: string
+        - in: query
+          name: wine_type
+          schema:
+            type: string
+        - in: query
+          name: producer
+          schema:
+            type: string
+        - in: query
+          name: search
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            type: integer
+        - in: query
+          name: offset
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Wine catalog.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Wine'
+        '500':
+          description: Unable to load wines.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags: [Wines]
+      summary: Add a new wine with vintage intelligence.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [wine, vintage, stock]
+              properties:
+                wine:
+                  type: object
+                  additionalProperties: true
+                vintage:
+                  type: object
+                  additionalProperties: true
+                stock:
+                  type: object
+                  additionalProperties: true
+      responses:
+        '201':
+          description: Wine added to inventory.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    $ref: '#/components/schemas/Wine'
+                  message:
+                    type: string
+        '400':
+          description: Missing required sections.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to add wine.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /wines/{id}:
+    get:
+      tags: [Wines]
+      summary: Retrieve a wine with detailed vintages and aliases.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Wine record with enrichments.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    $ref: '#/components/schemas/Wine'
+        '404':
+          description: Wine not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to load wine details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /vintage/analysis/{wine_id}:
+    get:
+      tags: [Vintage Intelligence]
+      summary: Retrieve analysis for a wine.
+      parameters:
+        - in: path
+          name: wine_id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Vintage analysis.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    $ref: '#/components/schemas/VintageAnalysis'
+        '404':
+          description: Wine not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to load analysis.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /vintage/procurement-recommendations:
+    get:
+      tags: [Vintage Intelligence]
+      summary: Retrieve procurement recommendations based on inventory gaps.
+      responses:
+        '200':
+          description: Procurement recommendations.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
+        '500':
+          description: Unable to load recommendations.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /vintage/batch-enrich:
+    post:
+      tags: [Vintage Intelligence]
+      summary: Batch enrich wines with vintage intelligence.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                filters:
+                  type: object
+                  additionalProperties: true
+                limit:
+                  type: integer
+      responses:
+        '200':
+          description: Batch enrichment results.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
+        '500':
+          description: Unable to perform batch enrichment.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /vintage/pairing-insight:
+    post:
+      tags: [Vintage Intelligence]
+      summary: Generate weather-based pairing insights for a wine and dish context.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [wine_id, dish_context]
+              properties:
+                wine_id:
+                  type: integer
+                dish_context:
+                  type: object
+                  additionalProperties: true
+      responses:
+        '200':
+          description: Pairing insight generated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Missing required fields.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Wine not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unable to generate pairing insight.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /system/health:
+    get:
+      tags: [System]
+      summary: Application health check.
+      responses:
+        '200':
+          description: System is healthy.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  status:
+                    type: string
+                  timestamp:
+                    type: string
+                    format: date-time
+                  data:
+                    type: object
+                    additionalProperties: true
+        '500':
+          description: System health degraded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /system/activity:
+    get:
+      tags: [System]
+      summary: Retrieve recent system activity.
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Activity events.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ActivityEvent'
+        '500':
+          description: Unable to load activity feed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'

--- a/backend/api/routes.js
+++ b/backend/api/routes.js
@@ -10,6 +10,7 @@ const LearningEngine = require('../core/learning_engine');
 const VintageIntelligenceService = require('../core/vintage_intelligence');
 const wineGuidanceService = require('../core/wine_guidance_service');
 const Database = require('../database/connection');
+const { validate, validators } = require('../middleware/validate');
 
 let servicesPromise = null;
 
@@ -77,7 +78,7 @@ const asyncHandler = (fn) => (req, res, next) => {
 
 // POST /api/pairing/recommend
 // Generate wine pairing recommendations
-router.post('/pairing/recommend', asyncHandler(withServices(async ({ pairingEngine }, req, res) => {
+router.post('/pairing/recommend', validate(validators.pairingRecommend), asyncHandler(withServices(async ({ pairingEngine }, req, res) => {
     const { dish, context, guestPreferences, options } = req.body;
 
     if (!dish) {
@@ -116,7 +117,7 @@ router.post('/pairing/recommend', asyncHandler(withServices(async ({ pairingEngi
 
 // POST /api/pairing/quick
 // Quick pairing for immediate service
-router.post('/pairing/quick', asyncHandler(withServices(async ({ pairingEngine }, req, res) => {
+router.post('/pairing/quick', validate(validators.pairingQuick), asyncHandler(withServices(async ({ pairingEngine }, req, res) => {
     const { dish, context, ownerLikes } = req.body;
 
     try {
@@ -136,7 +137,7 @@ router.post('/pairing/quick', asyncHandler(withServices(async ({ pairingEngine }
 
 // POST /api/pairing/feedback
 // Capture owner feedback to improve future pairings
-router.post('/pairing/feedback', asyncHandler(withServices(async ({ learningEngine }, req, res) => {
+router.post('/pairing/feedback', validate(validators.pairingFeedback), asyncHandler(withServices(async ({ learningEngine }, req, res) => {
     const { recommendation_id, rating, notes, selected = true } = req.body || {};
 
     if (!recommendation_id || !rating) {
@@ -167,7 +168,7 @@ router.post('/pairing/feedback', asyncHandler(withServices(async ({ learningEngi
 
 // GET /api/inventory
 // Paginated inventory list
-router.get('/inventory', asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
+router.get('/inventory', validate(validators.inventoryList), asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
     const { location, wine_type, region, available_only, limit, offset } = req.query;
 
     const result = await inventoryManager.getInventoryList(
@@ -198,7 +199,7 @@ router.get('/inventory', asyncHandler(withServices(async ({ inventoryManager }, 
 
 // GET /api/inventory/stock
 // Get current stock levels
-router.get('/inventory/stock', asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
+router.get('/inventory/stock', validate(validators.inventoryStock), asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
     const { location, wine_type, region, available_only } = req.query;
 
     try {
@@ -223,7 +224,7 @@ router.get('/inventory/stock', asyncHandler(withServices(async ({ inventoryManag
 
 // GET /api/inventory/:id
 // Retrieve a specific stock item by identifier
-router.get('/inventory/:id', asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
+router.get('/inventory/:id', validate(validators.inventoryById), asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
     const { id } = req.params;
 
     const stockItem = await inventoryManager.getStockItemById(id);
@@ -246,7 +247,7 @@ router.get('/inventory/:id', asyncHandler(withServices(async ({ inventoryManager
 
 // GET /api/locations
 // List available storage locations
-router.get('/locations', asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
+router.get('/locations', validate(), asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
     const locations = await inventoryManager.listLocations();
 
     res.json({
@@ -257,7 +258,7 @@ router.get('/locations', asyncHandler(withServices(async ({ inventoryManager }, 
 
 // POST /api/inventory/consume
 // Record wine consumption
-router.post('/inventory/consume', asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
+router.post('/inventory/consume', validate(validators.inventoryConsume), asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
     const { vintage_id, location, quantity, notes, created_by } = req.body;
 
     if (!vintage_id || !location || !quantity) {
@@ -290,7 +291,7 @@ router.post('/inventory/consume', asyncHandler(withServices(async ({ inventoryMa
 
 // POST /api/inventory/receive
 // Record wine receipt/delivery
-router.post('/inventory/receive', asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
+router.post('/inventory/receive', validate(validators.inventoryReceive), asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
     const { vintage_id, location, quantity, unit_cost, reference_id, notes, created_by } = req.body;
 
     if (!vintage_id || !location || !quantity) {
@@ -325,7 +326,7 @@ router.post('/inventory/receive', asyncHandler(withServices(async ({ inventoryMa
 
 // POST /api/inventory/intake
 // Create a new intake order from external sources
-router.post('/inventory/intake', asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
+router.post('/inventory/intake', validate(validators.inventoryIntake), asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
     try {
         const result = await inventoryManager.createInventoryIntake(req.body || {});
         res.json({
@@ -343,7 +344,7 @@ router.post('/inventory/intake', asyncHandler(withServices(async ({ inventoryMan
 
 // POST /api/inventory/intake/:intakeId/receive
 // Mark bottles as received against an intake order
-router.post('/inventory/intake/:intakeId/receive', asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
+router.post('/inventory/intake/:intakeId/receive', validate(validators.inventoryIntakeReceive), asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
     const intakeId = parseInt(req.params.intakeId, 10);
     const { receipts, created_by, notes } = req.body || {};
 
@@ -376,7 +377,7 @@ router.post('/inventory/intake/:intakeId/receive', asyncHandler(withServices(asy
 
 // GET /api/inventory/intake/:intakeId/status
 // Verify whether all bottles from an intake have been received
-router.get('/inventory/intake/:intakeId/status', asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
+router.get('/inventory/intake/:intakeId/status', validate(validators.inventoryIntakeStatus), asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
     const intakeId = parseInt(req.params.intakeId, 10);
 
     try {
@@ -396,7 +397,7 @@ router.get('/inventory/intake/:intakeId/status', asyncHandler(withServices(async
 
 // POST /api/inventory/move
 // Move wine between locations
-router.post('/inventory/move', asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
+router.post('/inventory/move', validate(validators.inventoryMove), asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
     const { vintage_id, from_location, to_location, quantity, notes, created_by } = req.body;
 
     if (!vintage_id || !from_location || !to_location || !quantity) {
@@ -430,7 +431,7 @@ router.post('/inventory/move', asyncHandler(withServices(async ({ inventoryManag
 
 // POST /api/inventory/reserve
 // Reserve wine for future service
-router.post('/inventory/reserve', asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
+router.post('/inventory/reserve', validate(validators.inventoryReserve), asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
     const { vintage_id, location, quantity, notes, created_by } = req.body;
 
     if (!vintage_id || !location || !quantity) {
@@ -463,7 +464,7 @@ router.post('/inventory/reserve', asyncHandler(withServices(async ({ inventoryMa
 
 // GET /api/inventory/ledger/:vintage_id
 // Get transaction history for a vintage
-router.get('/inventory/ledger/:vintage_id', asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
+router.get('/inventory/ledger/:vintage_id', validate(validators.inventoryLedger), asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
     const { vintage_id } = req.params;
     const { limit = 50, offset = 0 } = req.query;
 
@@ -492,7 +493,7 @@ router.get('/inventory/ledger/:vintage_id', asyncHandler(withServices(async ({ i
 
 // GET /api/procurement/opportunities
 // Get procurement opportunities
-router.get('/procurement/opportunities', asyncHandler(withServices(async ({ procurementEngine }, req, res) => {
+router.get('/procurement/opportunities', validate(validators.procurementOpportunities), asyncHandler(withServices(async ({ procurementEngine }, req, res) => {
     const { region, regions, wine_type, wine_types, max_price, min_score, budget } = req.query;
 
     try {
@@ -520,7 +521,7 @@ router.get('/procurement/opportunities', asyncHandler(withServices(async ({ proc
 
 // POST /api/procurement/analyze
 // Analyze specific procurement decision
-router.post('/procurement/analyze', asyncHandler(withServices(async ({ procurementEngine }, req, res) => {
+router.post('/procurement/analyze', validate(validators.procurementAnalyze), asyncHandler(withServices(async ({ procurementEngine }, req, res) => {
     const { vintage_id, supplier_id, quantity, context } = req.body;
 
     if (!vintage_id || !supplier_id) {
@@ -552,7 +553,7 @@ router.post('/procurement/analyze', asyncHandler(withServices(async ({ procureme
 
 // POST /api/procurement/order
 // Generate purchase order
-router.post('/procurement/order', asyncHandler(withServices(async ({ procurementEngine }, req, res) => {
+router.post('/procurement/order', validate(validators.procurementOrder), asyncHandler(withServices(async ({ procurementEngine }, req, res) => {
     const { items, supplier_id, delivery_date, notes } = req.body;
 
     if (!items || !Array.isArray(items) || items.length === 0) {
@@ -595,7 +596,7 @@ router.post('/procurement/order', asyncHandler(withServices(async ({ procurement
 
 // GET /api/wines
 // Get wine catalog
-router.get('/wines', asyncHandler(withServices(async ({ db }, req, res) => {
+router.get('/wines', validate(validators.winesList), asyncHandler(withServices(async ({ db }, req, res) => {
     const { region, wine_type, producer, search, limit = 50, offset = 0 } = req.query;
 
     try {
@@ -656,7 +657,7 @@ router.get('/wines', asyncHandler(withServices(async ({ db }, req, res) => {
 
 // POST /api/wines
 // Add new wine to inventory with vintage intelligence
-router.post('/wines', asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
+router.post('/wines', validate(validators.winesCreate), asyncHandler(withServices(async ({ inventoryManager }, req, res) => {
     const { wine, vintage, stock } = req.body;
 
     if (!wine || !vintage || !stock) {
@@ -684,7 +685,7 @@ router.post('/wines', asyncHandler(withServices(async ({ inventoryManager }, req
 
 // GET /api/wines/:id
 // Get specific wine details
-router.get('/wines/:id', asyncHandler(withServices(async ({ db }, req, res) => {
+router.get('/wines/:id', validate(validators.winesById), asyncHandler(withServices(async ({ db }, req, res) => {
     const { id } = req.params;
 
     try {
@@ -749,7 +750,7 @@ router.get('/wines/:id', asyncHandler(withServices(async ({ db }, req, res) => {
 
 // GET /api/vintage/analysis/:wine_id
 // Get vintage analysis for specific wine
-router.get('/vintage/analysis/:wine_id', asyncHandler(withServices(async ({ db, vintageIntelligenceService }, req, res) => {
+router.get('/vintage/analysis/:wine_id', validate(validators.vintageAnalysis), asyncHandler(withServices(async ({ db, vintageIntelligenceService }, req, res) => {
     const { wine_id } = req.params;
 
     try {
@@ -820,7 +821,7 @@ router.get('/vintage/analysis/:wine_id', asyncHandler(withServices(async ({ db, 
 
 // POST /api/vintage/enrich
 // Manually trigger vintage enrichment for a specific wine
-router.post('/vintage/enrich', asyncHandler(withServices(async ({ db, vintageIntelligenceService }, req, res) => {
+router.post('/vintage/enrich', validate(validators.vintageEnrich), asyncHandler(withServices(async ({ db, vintageIntelligenceService }, req, res) => {
     const { wine_id } = req.body;
 
     if (!wine_id) {
@@ -864,7 +865,7 @@ router.post('/vintage/enrich', asyncHandler(withServices(async ({ db, vintageInt
 
 // GET /api/vintage/procurement-recommendations
 // Get procurement recommendations for current inventory
-router.get('/vintage/procurement-recommendations', asyncHandler(withServices(async ({ vintageIntelligenceService }, req, res) => {
+router.get('/vintage/procurement-recommendations', validate(), asyncHandler(withServices(async ({ vintageIntelligenceService }, req, res) => {
     try {
         const recommendations = await vintageIntelligenceService.getInventoryProcurementRecommendations();
 
@@ -882,7 +883,7 @@ router.get('/vintage/procurement-recommendations', asyncHandler(withServices(asy
 
 // POST /api/vintage/batch-enrich
 // Batch enrich multiple wines with vintage intelligence
-router.post('/vintage/batch-enrich', asyncHandler(withServices(async ({ db, vintageIntelligenceService }, req, res) => {
+router.post('/vintage/batch-enrich', validate(validators.vintageBatchEnrich), asyncHandler(withServices(async ({ db, vintageIntelligenceService }, req, res) => {
     const { filters = {}, limit = 50 } = req.body;
 
     try {
@@ -947,7 +948,7 @@ router.post('/vintage/batch-enrich', asyncHandler(withServices(async ({ db, vint
 
 // GET /api/vintage/pairing-insight
 // Get weather-based pairing insights for a wine and dish context
-router.post('/vintage/pairing-insight', asyncHandler(withServices(async ({ db, vintageIntelligenceService }, req, res) => {
+router.post('/vintage/pairing-insight', validate(validators.vintagePairingInsight), asyncHandler(withServices(async ({ db, vintageIntelligenceService }, req, res) => {
     const { wine_id, dish_context } = req.body;
 
     if (!wine_id || !dish_context) {
@@ -1006,7 +1007,7 @@ router.post('/vintage/pairing-insight', asyncHandler(withServices(async ({ db, v
 
 // GET /api/system/health
 // System health check
-router.get('/system/health', asyncHandler(async (req, res) => {
+router.get('/system/health', validate(), asyncHandler(async (req, res) => {
     try {
         const db = Database.getInstance();
 
@@ -1039,7 +1040,7 @@ router.get('/system/health', asyncHandler(async (req, res) => {
 
 // GET /api/system/activity
 // Recent system activity derived from ledger and intake updates
-router.get('/system/activity', asyncHandler(withServices(async ({ db }, req, res) => {
+router.get('/system/activity', validate(validators.systemActivity), asyncHandler(withServices(async ({ db }, req, res) => {
     const { limit = 10 } = req.query;
 
     const parsedLimit = Number.parseInt(limit, 10);

--- a/backend/middleware/validate.js
+++ b/backend/middleware/validate.js
@@ -1,0 +1,267 @@
+const { z, ZodError } = require("zod");
+
+const nonEmptyString = z.string().min(1, { message: "Value is required." });
+const generalObject = z.object({}).passthrough();
+const optionalNonEmptyString = nonEmptyString.optional();
+
+const numberLike = z.union([
+  z.number(),
+  z.string().regex(/^-?\d+(\.\d+)?$/, { message: "Must be a number." }),
+]);
+
+const integerLike = z.union([
+  z.number().int(),
+  z.string().regex(/^-?\d+$/, { message: "Must be an integer." }),
+]);
+
+const booleanLike = z.union([z.boolean(), z.enum(["true", "false"])]);
+
+const stringOrStringArray = z.union([nonEmptyString, z.array(nonEmptyString)]);
+
+const passthroughObject = (shape) => generalObject.extend(shape);
+
+const validators = {
+  pairingRecommend: {
+    body: passthroughObject({
+      dish: z.union([nonEmptyString, generalObject]),
+      context: generalObject.optional(),
+      guestPreferences: generalObject.optional(),
+      options: generalObject.optional(),
+    }),
+  },
+  pairingQuick: {
+    body: passthroughObject({
+      dish: z.union([nonEmptyString, generalObject]).optional(),
+      context: generalObject.optional(),
+      ownerLikes: generalObject.optional(),
+    }),
+  },
+  pairingFeedback: {
+    body: passthroughObject({
+      recommendation_id: nonEmptyString,
+      rating: numberLike,
+      notes: optionalNonEmptyString,
+      selected: booleanLike.optional(),
+    }),
+  },
+  inventoryList: {
+    query: z
+      .object({
+        location: optionalNonEmptyString,
+        wine_type: optionalNonEmptyString,
+        region: optionalNonEmptyString,
+        available_only: booleanLike.optional(),
+        limit: integerLike.optional(),
+        offset: integerLike.optional(),
+      })
+      .passthrough(),
+  },
+  inventoryStock: {
+    query: z
+      .object({
+        location: optionalNonEmptyString,
+        wine_type: optionalNonEmptyString,
+        region: optionalNonEmptyString,
+        available_only: booleanLike.optional(),
+      })
+      .passthrough(),
+  },
+  inventoryById: {
+    params: z.object({
+      id: nonEmptyString,
+    }),
+  },
+  inventoryConsume: {
+    body: passthroughObject({
+      vintage_id: z.union([nonEmptyString, integerLike]),
+      location: nonEmptyString,
+      quantity: numberLike,
+      notes: optionalNonEmptyString,
+      created_by: optionalNonEmptyString,
+    }),
+  },
+  inventoryReceive: {
+    body: passthroughObject({
+      vintage_id: z.union([nonEmptyString, integerLike]),
+      location: nonEmptyString,
+      quantity: numberLike,
+      unit_cost: numberLike.optional(),
+      reference_id: optionalNonEmptyString,
+      notes: optionalNonEmptyString,
+      created_by: optionalNonEmptyString,
+    }),
+  },
+  inventoryIntake: {
+    body: generalObject,
+  },
+  inventoryIntakeReceive: {
+    params: z.object({
+      intakeId: integerLike,
+    }),
+    body: passthroughObject({
+      receipts: z
+        .array(generalObject)
+        .min(1, { message: "At least one receipt is required." }),
+      created_by: optionalNonEmptyString,
+      notes: optionalNonEmptyString,
+    }),
+  },
+  inventoryIntakeStatus: {
+    params: z.object({
+      intakeId: integerLike,
+    }),
+  },
+  inventoryMove: {
+    body: passthroughObject({
+      vintage_id: z.union([nonEmptyString, integerLike]),
+      from_location: nonEmptyString,
+      to_location: nonEmptyString,
+      quantity: numberLike,
+      notes: optionalNonEmptyString,
+      created_by: optionalNonEmptyString,
+    }),
+  },
+  inventoryReserve: {
+    body: passthroughObject({
+      vintage_id: z.union([nonEmptyString, integerLike]),
+      location: nonEmptyString,
+      quantity: numberLike,
+      notes: optionalNonEmptyString,
+      created_by: optionalNonEmptyString,
+    }),
+  },
+  inventoryLedger: {
+    params: z.object({
+      vintage_id: nonEmptyString,
+    }),
+    query: z
+      .object({
+        limit: integerLike.optional(),
+        offset: integerLike.optional(),
+      })
+      .passthrough(),
+  },
+  procurementOpportunities: {
+    query: z
+      .object({
+        region: optionalNonEmptyString,
+        regions: stringOrStringArray.optional(),
+        wine_type: optionalNonEmptyString,
+        wine_types: stringOrStringArray.optional(),
+        max_price: numberLike.optional(),
+        min_score: integerLike.optional(),
+        budget: numberLike.optional(),
+      })
+      .passthrough(),
+  },
+  procurementAnalyze: {
+    body: passthroughObject({
+      vintage_id: z.union([nonEmptyString, integerLike]),
+      supplier_id: z.union([nonEmptyString, integerLike]),
+      quantity: numberLike.optional(),
+      context: generalObject.optional(),
+    }),
+  },
+  procurementOrder: {
+    body: passthroughObject({
+      items: z
+        .array(generalObject)
+        .min(1, { message: "Items array must include at least one entry." }),
+      supplier_id: z.union([nonEmptyString, integerLike]),
+      delivery_date: optionalNonEmptyString,
+      notes: optionalNonEmptyString,
+    }),
+  },
+  winesList: {
+    query: z
+      .object({
+        region: optionalNonEmptyString,
+        wine_type: optionalNonEmptyString,
+        producer: optionalNonEmptyString,
+        search: optionalNonEmptyString,
+        limit: integerLike.optional(),
+        offset: integerLike.optional(),
+      })
+      .passthrough(),
+  },
+  winesCreate: {
+    body: passthroughObject({
+      wine: generalObject,
+      vintage: generalObject,
+      stock: generalObject,
+    }),
+  },
+  winesById: {
+    params: z.object({
+      id: nonEmptyString,
+    }),
+  },
+  vintageAnalysis: {
+    params: z.object({
+      wine_id: nonEmptyString,
+    }),
+  },
+  vintageEnrich: {
+    body: passthroughObject({
+      wine_id: z.union([nonEmptyString, integerLike]),
+    }),
+  },
+  vintageBatchEnrich: {
+    body: passthroughObject({
+      filters: generalObject.optional(),
+      limit: integerLike.optional(),
+    }),
+  },
+  vintagePairingInsight: {
+    body: passthroughObject({
+      wine_id: z.union([nonEmptyString, integerLike]),
+      dish_context: generalObject,
+    }),
+  },
+  systemActivity: {
+    query: z
+      .object({
+        limit: integerLike.optional(),
+      })
+      .passthrough(),
+  },
+};
+
+const validate = (schemaConfig) => {
+  const config = schemaConfig || {};
+
+  return (req, res, next) => {
+    try {
+      if (config.params) {
+        req.params = config.params.parse(req.params || {});
+      }
+
+      if (config.query) {
+        req.query = config.query.parse(req.query || {});
+      }
+
+      if (config.body) {
+        req.body = config.body.parse(req.body || {});
+      }
+
+      return next();
+    } catch (error) {
+      if (error instanceof ZodError) {
+        const details = error.issues.map((issue) => ({
+          path: issue.path.join(".") || null,
+          message: issue.message,
+        }));
+
+        return res.status(400).json({
+          success: false,
+          error: "Invalid request.",
+          details,
+        });
+      }
+
+      return next(error);
+    }
+  };
+};
+
+module.exports = { validate, validators };

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "morgan": "^1.10.1",
         "node-cron": "^3.0.2",
         "openai": "^5.23.0",
-        "sqlite3": "^5.1.6"
+        "sqlite3": "^5.1.6",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "concurrently": "^8.2.0",
@@ -8109,6 +8110,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "morgan": "^1.10.1",
     "node-cron": "^3.0.2",
     "openai": "^5.23.0",
-    "sqlite3": "^5.1.6"
+    "sqlite3": "^5.1.6",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "concurrently": "^8.2.0",


### PR DESCRIPTION
## Summary
- add backend/middleware/validate.js with shared Zod schemas and a reusable Express validation helper
- wire the validator across backend/api/routes.js so every API endpoint checks params, query strings, and bodies
- add the zod dependency to the project manifests for backend use

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daa8db59a0832b997a90dc56866416