### PR TITLE
Add configurable auth bypass and regression tests

### DIFF
--- a/backend/api/auth.js
+++ b/backend/api/auth.js
@@ -1,0 +1,224 @@
+const express = require('express');
+
+const { validate, validators } = require('../middleware/validate');
+const { authService, requireAuth, requireRole } = require('../middleware/auth');
+
+const router = express.Router();
+
+const asyncHandler = (fn) => (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+};
+
+const sendError = (res, status, code, message, details) => {
+    const payload = {
+        success: false,
+        error: {
+            code,
+            message,
+        },
+    };
+
+    if (typeof details !== 'undefined') {
+        payload.error.details = details;
+    }
+
+    return res.status(status).json(payload);
+};
+
+router.post(
+    '/register',
+    validate(validators.authRegister),
+    asyncHandler(async (req, res) => {
+        const { email, password } = req.body;
+
+        const existingCount = await authService.getUserCount();
+
+        if (existingCount > 0) {
+            return sendError(
+                res,
+                403,
+                'REGISTRATION_DISABLED',
+                'Direct registration is disabled after the first account is created.'
+            );
+        }
+
+        const existingUser = await authService.getUserByEmail(email);
+
+        if (existingUser) {
+            return sendError(res, 409, 'USER_EXISTS', 'An account with this email already exists.');
+        }
+
+        const user = await authService.createUser({ email, password, role: 'admin' });
+        const tokens = await authService.issueTokensForUser(user);
+        authService.attachTokensToResponse(res, tokens);
+
+        const freshUser = await authService.getUserById(user.id);
+
+        return res.status(201).json({
+            success: true,
+            data: authService.serializeUser(freshUser),
+        });
+    })
+);
+
+router.post(
+    '/login',
+    validate(validators.authLogin),
+    asyncHandler(async (req, res) => {
+        const { email, password } = req.body;
+
+        const user = await authService.getUserByEmail(email);
+
+        if (!user) {
+            return sendError(res, 401, 'INVALID_CREDENTIALS', 'Invalid email or password.');
+        }
+
+        const validPassword = await authService.verifyPassword(password, user.password_hash);
+
+        if (!validPassword) {
+            return sendError(res, 401, 'INVALID_CREDENTIALS', 'Invalid email or password.');
+        }
+
+        const tokens = await authService.issueTokensForUser(user);
+        authService.attachTokensToResponse(res, tokens);
+
+        const freshUser = await authService.getUserById(user.id);
+
+        return res.json({
+            success: true,
+            data: authService.serializeUser(freshUser),
+        });
+    })
+);
+
+router.post(
+    '/logout',
+    requireAuth(),
+    asyncHandler(async (req, res) => {
+        const refreshToken = req.cookies?.sommos_refresh_token;
+
+        if (refreshToken) {
+            await authService.removeRefreshToken(refreshToken);
+        }
+
+        authService.clearAuthCookies(res);
+
+        return res.json({
+            success: true,
+            message: 'Logged out successfully.',
+        });
+    })
+);
+
+router.post(
+    '/refresh',
+    asyncHandler(async (req, res) => {
+        const refreshToken = req.cookies?.sommos_refresh_token;
+
+        if (!refreshToken) {
+            return sendError(res, 401, 'REFRESH_TOKEN_MISSING', 'Refresh token is required.');
+        }
+
+        try {
+            const { user } = await authService.validateRefreshToken(refreshToken);
+            const tokens = await authService.rotateRefreshToken(refreshToken, user);
+            authService.attachTokensToResponse(res, tokens);
+
+            const freshUser = await authService.getUserById(user.id);
+
+            return res.json({
+                success: true,
+                data: authService.serializeUser(freshUser),
+            });
+        } catch (error) {
+            authService.clearAuthCookies(res);
+
+            return sendError(
+                res,
+                401,
+                'REFRESH_TOKEN_INVALID',
+                error.message || 'Refresh token is invalid or has expired.'
+            );
+        }
+    })
+);
+
+router.post(
+    '/invite',
+    requireRole('admin'),
+    validate(validators.authInvite),
+    asyncHandler(async (req, res) => {
+        const { email, role, expires_in_hours, pin } = req.body;
+
+        const expiresInMs = expires_in_hours
+            ? Number(expires_in_hours) * 60 * 60 * 1000
+            : undefined;
+
+        if (expiresInMs && (!Number.isFinite(expiresInMs) || expiresInMs <= 0)) {
+            return sendError(res, 400, 'INVALID_INVITE_EXPIRATION', 'expires_in_hours must be positive.');
+        }
+
+        try {
+            const invite = await authService.createInvite({
+                email,
+                role,
+                expiresInMs,
+                pin,
+            });
+
+            return res.status(201).json({
+                success: true,
+                data: invite,
+            });
+        } catch (error) {
+            return sendError(
+                res,
+                400,
+                'INVITE_CREATION_FAILED',
+                error.message || 'Failed to create invite.'
+            );
+        }
+    })
+);
+
+router.post(
+    '/accept-invite',
+    validate(validators.authAcceptInvite),
+    asyncHandler(async (req, res) => {
+        const { token, password, pin } = req.body;
+
+        try {
+            const user = await authService.consumeInvite(token, { password, pin });
+            const tokens = await authService.issueTokensForUser(user);
+            authService.attachTokensToResponse(res, tokens);
+
+            const freshUser = await authService.getUserById(user.id);
+
+            return res.json({
+                success: true,
+                data: authService.serializeUser(freshUser),
+            });
+        } catch (error) {
+            const message = error.message || 'Unable to accept invite.';
+
+            if (['PIN_REQUIRED', 'INVALID_PIN', 'PASSWORD_REQUIRED'].includes(error.message)) {
+                return sendError(res, 400, error.message, message);
+            }
+
+            return sendError(res, 400, 'INVALID_INVITE', message);
+        }
+    })
+);
+
+router.get(
+    '/me',
+    requireAuth(),
+    asyncHandler(async (req, res) => {
+        return res.json({
+            success: true,
+            data: req.user,
+        });
+    })
+);
+
+module.exports = router;

--- a/backend/api/openapi.yaml
+++ b/backend/api/openapi.yaml
@@ -117,11 +117,374 @@ components:
         timestamp:
           type: string
           format: date-time
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+          enum: [admin, crew, guest]
+        created_at:
+          type: string
+          format: date-time
+        last_login:
+          type: string
+          format: date-time
+          nullable: true
+    Invite:
+      type: object
+      properties:
+        token:
+          type: string
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+          enum: [admin, crew, guest]
+        expires_at:
+          type: string
+          format: date-time
+        requires_pin:
+          type: boolean
+  securitySchemes:
+    accessTokenCookie:
+      type: apiKey
+      in: cookie
+      name: sommos_access_token
+      description: >-
+        Short-lived JWT issued after authentication. Required for protected mutations.
+    refreshTokenCookie:
+      type: apiKey
+      in: cookie
+      name: sommos_refresh_token
+      description: >-
+        Long-lived refresh token stored as an HttpOnly cookie. Used only with the refresh endpoint.
 paths:
+  /guest/session:
+    post:
+      tags: [Auth]
+      summary: Issue a temporary guest session using an event code.
+      description: |
+        Establishes a time-limited guest session by validating an admin issued guest invite
+        or event code. On success the response sets httpOnly access and refresh token cookies
+        scoped to read-only permissions.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                event_code:
+                  type: string
+                  description: Guest invite or event code shared by the crew.
+                invite_token:
+                  type: string
+                  description: Legacy field alias for `event_code`.
+                pin:
+                  type: string
+                  description: Optional PIN required when configured on the invite.
+              anyOf:
+                - required: [event_code]
+                - required: [invite_token]
+      responses:
+        '201':
+          description: Guest session created; authentication cookies issued.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    $ref: '#/components/schemas/User'
+                  meta:
+                    type: object
+                    properties:
+                      access_token_expires_in:
+                        type: integer
+                        description: Access token expiration window in seconds.
+                      refresh_token_expires_in:
+                        type: integer
+                        description: Refresh token expiration window in seconds.
+        '400':
+          description: Missing required event code or PIN validation failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Provided PIN does not match the invite.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Event code not found or expired.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Guest session could not be created due to a server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /auth/register:
+    post:
+      tags: [Auth]
+      summary: Provision the initial administrator account.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email, password]
+              properties:
+                email:
+                  type: string
+                  format: email
+                password:
+                  type: string
+                  minLength: 8
+      responses:
+        '201':
+          description: Administrator account created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    $ref: '#/components/schemas/User'
+        '403':
+          description: Registration disabled when an account already exists.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Email already registered.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /auth/login:
+    post:
+      tags: [Auth]
+      summary: Authenticate a user and issue cookies.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email, password]
+              properties:
+                email:
+                  type: string
+                  format: email
+                password:
+                  type: string
+      responses:
+        '200':
+          description: Login succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    $ref: '#/components/schemas/User'
+        '401':
+          description: Invalid credentials.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /auth/logout:
+    post:
+      tags: [Auth]
+      summary: End the active session and clear cookies.
+      security:
+        - accessTokenCookie: []
+      responses:
+        '200':
+          description: Logout successful.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  message:
+                    type: string
+        '401':
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /auth/refresh:
+    post:
+      tags: [Auth]
+      summary: Rotate session tokens using the refresh cookie.
+      security:
+        - refreshTokenCookie: []
+      responses:
+        '200':
+          description: Session refreshed.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    $ref: '#/components/schemas/User'
+        '401':
+          description: Refresh token missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /auth/invite:
+    post:
+      tags: [Auth]
+      summary: Issue a role-based invite link.
+      security:
+        - accessTokenCookie: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email, role]
+              properties:
+                email:
+                  type: string
+                  format: email
+                role:
+                  type: string
+                  enum: [admin, crew, guest]
+                expires_in_hours:
+                  type: integer
+                  minimum: 1
+                pin:
+                  type: string
+      responses:
+        '201':
+          description: Invite created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    $ref: '#/components/schemas/Invite'
+        '400':
+          description: Invalid invite request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /auth/accept-invite:
+    post:
+      tags: [Auth]
+      summary: Exchange an invite for an authenticated session.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [token]
+              properties:
+                token:
+                  type: string
+                password:
+                  type: string
+                pin:
+                  type: string
+      responses:
+        '200':
+          description: Invite accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    $ref: '#/components/schemas/User'
+        '400':
+          description: Invalid invite payload.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /auth/me:
+    get:
+      tags: [Auth]
+      summary: Retrieve the authenticated user profile.
+      security:
+        - accessTokenCookie: []
+      responses:
+        '200':
+          description: Current session details.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    $ref: '#/components/schemas/User'
+        '401':
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /pairing/recommend:
     post:
       tags: [Pairing]
       summary: Generate wine pairing recommendations.
+      security:
+        - accessTokenCookie: []
       requestBody:
         required: true
         content:
@@ -181,6 +544,8 @@ paths:
     post:
       tags: [Pairing]
       summary: Request expedited pairing suggestions.
+      security:
+        - accessTokenCookie: []
       requestBody:
         required: true
         content:
@@ -225,6 +590,8 @@ paths:
     post:
       tags: [Pairing]
       summary: Record feedback for a pairing recommendation.
+      security:
+        - accessTokenCookie: []
       requestBody:
         required: true
         content:
@@ -423,6 +790,8 @@ paths:
     post:
       tags: [Inventory]
       summary: Record wine consumption.
+      security:
+        - accessTokenCookie: []
       requestBody:
         required: true
         content:
@@ -471,6 +840,8 @@ paths:
     post:
       tags: [Inventory]
       summary: Record incoming wine.
+      security:
+        - accessTokenCookie: []
       requestBody:
         required: true
         content:
@@ -523,6 +894,8 @@ paths:
     post:
       tags: [Inventory]
       summary: Create an intake order.
+      security:
+        - accessTokenCookie: []
       requestBody:
         required: true
         content:
@@ -560,6 +933,8 @@ paths:
     post:
       tags: [Inventory]
       summary: Mark items as received for an intake order.
+      security:
+        - accessTokenCookie: []
       parameters:
         - in: path
           name: intakeId
@@ -649,6 +1024,8 @@ paths:
     post:
       tags: [Inventory]
       summary: Move wine between locations.
+      security:
+        - accessTokenCookie: []
       requestBody:
         required: true
         content:
@@ -699,6 +1076,8 @@ paths:
     post:
       tags: [Inventory]
       summary: Reserve wine for future service.
+      security:
+        - accessTokenCookie: []
       requestBody:
         required: true
         content:
@@ -842,6 +1221,8 @@ paths:
     post:
       tags: [Procurement]
       summary: Analyze a specific procurement decision.
+      security:
+        - accessTokenCookie: []
       requestBody:
         required: true
         content:
@@ -889,6 +1270,8 @@ paths:
     post:
       tags: [Procurement]
       summary: Generate a purchase order.
+      security:
+        - accessTokenCookie: []
       requestBody:
         required: true
         content:
@@ -988,6 +1371,8 @@ paths:
     post:
       tags: [Wines]
       summary: Add a new wine with vintage intelligence.
+      security:
+        - accessTokenCookie: []
       requestBody:
         required: true
         content:
@@ -1106,6 +1491,8 @@ paths:
     post:
       tags: [Vintage Intelligence]
       summary: Enrich a wine record with the latest intelligence data.
+      security:
+        - accessTokenCookie: []
       requestBody:
         required: true
         content:
@@ -1183,6 +1570,8 @@ paths:
     post:
       tags: [Vintage Intelligence]
       summary: Batch enrich wines with vintage intelligence.
+      security:
+        - accessTokenCookie: []
       requestBody:
         required: true
         content:
@@ -1221,6 +1610,8 @@ paths:
     post:
       tags: [Vintage Intelligence]
       summary: Generate weather-based pairing insights for a wine and dish context.
+      security:
+        - accessTokenCookie: []
       requestBody:
         required: true
         content:

--- a/backend/core/auth_service.js
+++ b/backend/core/auth_service.js
@@ -1,0 +1,403 @@
+const bcrypt = require('bcrypt');
+const crypto = require('crypto');
+const jwt = require('jsonwebtoken');
+
+const Database = require('../database/connection');
+const { getConfig } = require('../config/env');
+
+const ACCESS_TOKEN_TTL_MS = 15 * 60 * 1000; // 15 minutes
+const REFRESH_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const STANDARD_INVITE_TTL_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
+const GUEST_INVITE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const GUEST_ACCESS_TOKEN_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const GUEST_REFRESH_TOKEN_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
+const BCRYPT_ROUNDS = 12;
+
+const ROLES = ['admin', 'crew', 'guest'];
+
+class AuthService {
+    constructor(options = {}) {
+        this.db = options.db || Database.getInstance();
+        this.config = options.config || getConfig();
+
+        const configuredSecret = this.config.auth && this.config.auth.jwtSecret;
+
+        if (configuredSecret) {
+            this.jwtSecret = configuredSecret;
+        } else if (this.config.isProduction) {
+            throw new Error('JWT_SECRET is not configured.');
+        } else {
+            this.jwtSecret = 'sommos-dev-secret';
+        }
+    }
+
+    static get Roles() {
+        return ROLES;
+    }
+
+    normalizeEmail(email) {
+        return (email || '').trim().toLowerCase();
+    }
+
+    async getUserByEmail(email) {
+        const normalized = this.normalizeEmail(email);
+        return this.db.get('SELECT * FROM Users WHERE email = ?', [normalized]);
+    }
+
+    async getUserById(id) {
+        return this.db.get('SELECT * FROM Users WHERE id = ?', [id]);
+    }
+
+    async getUserCount() {
+        const result = await this.db.get('SELECT COUNT(*) as count FROM Users');
+        return result?.count || 0;
+    }
+
+    async createUser({ email, password, role }) {
+        const normalized = this.normalizeEmail(email);
+
+        if (!ROLES.includes(role)) {
+            throw new Error('INVALID_ROLE');
+        }
+
+        const passwordHash = password ? await bcrypt.hash(password, BCRYPT_ROUNDS) : null;
+
+        const result = await this.db.run(
+            'INSERT INTO Users (email, password_hash, role) VALUES (?, ?, ?)',
+            [normalized, passwordHash, role]
+        );
+
+        return this.getUserById(result.lastID);
+    }
+
+    async updatePassword(userId, password) {
+        const passwordHash = password ? await bcrypt.hash(password, BCRYPT_ROUNDS) : null;
+        await this.db.run('UPDATE Users SET password_hash = ? WHERE id = ?', [passwordHash, userId]);
+    }
+
+    async updateRole(userId, role) {
+        if (!ROLES.includes(role)) {
+            throw new Error('INVALID_ROLE');
+        }
+        await this.db.run('UPDATE Users SET role = ? WHERE id = ?', [role, userId]);
+    }
+
+    async updateLastLogin(userId) {
+        const timestamp = new Date().toISOString();
+        await this.db.run('UPDATE Users SET last_login = ? WHERE id = ?', [timestamp, userId]);
+    }
+
+    async verifyPassword(password, hash) {
+        if (!hash) {
+            return false;
+        }
+        return bcrypt.compare(password, hash);
+    }
+
+    serializeUser(user) {
+        if (!user) {
+            return null;
+        }
+
+        return {
+            id: user.id,
+            email: user.email,
+            role: user.role,
+            created_at: user.created_at,
+            last_login: user.last_login,
+        };
+    }
+
+    generateAccessToken(user, ttlMs = ACCESS_TOKEN_TTL_MS) {
+        return jwt.sign(
+            {
+                sub: user.id,
+                role: user.role,
+                type: 'access',
+            },
+            this.jwtSecret,
+            { expiresIn: Math.floor(ttlMs / 1000) }
+        );
+    }
+
+    generateRefreshToken(user, ttlMs = REFRESH_TOKEN_TTL_MS) {
+        return jwt.sign(
+            {
+                sub: user.id,
+                role: user.role,
+                type: 'refresh',
+                jti: crypto.randomUUID(),
+            },
+            this.jwtSecret,
+            { expiresIn: Math.floor(ttlMs / 1000) }
+        );
+    }
+
+    hashToken(token) {
+        return crypto.createHash('sha256').update(token).digest('hex');
+    }
+
+    async storeRefreshToken(userId, token, ttlMs = REFRESH_TOKEN_TTL_MS) {
+        const tokenHash = this.hashToken(token);
+        const expiresAt = new Date(Date.now() + ttlMs).toISOString();
+
+        await this.db.run(
+            'INSERT INTO RefreshTokens (user_id, token_hash, expires_at) VALUES (?, ?, ?)',
+            [userId, tokenHash, expiresAt]
+        );
+    }
+
+    async removeRefreshToken(token) {
+        if (!token) {
+            return;
+        }
+
+        const tokenHash = this.hashToken(token);
+        await this.db.run('DELETE FROM RefreshTokens WHERE token_hash = ?', [tokenHash]);
+    }
+
+    async revokeUserRefreshTokens(userId) {
+        await this.db.run('DELETE FROM RefreshTokens WHERE user_id = ?', [userId]);
+    }
+
+    verifyAccessToken(token) {
+        const payload = jwt.verify(token, this.jwtSecret);
+
+        if (payload.type !== 'access') {
+            throw new Error('INVALID_TOKEN_TYPE');
+        }
+
+        return payload;
+    }
+
+    verifyRefreshToken(token) {
+        const payload = jwt.verify(token, this.jwtSecret);
+
+        if (payload.type !== 'refresh') {
+            throw new Error('INVALID_TOKEN_TYPE');
+        }
+
+        return payload;
+    }
+
+    async validateRefreshToken(token) {
+        const payload = this.verifyRefreshToken(token);
+        const tokenHash = this.hashToken(token);
+
+        const record = await this.db.get(
+            'SELECT * FROM RefreshTokens WHERE token_hash = ?',
+            [tokenHash]
+        );
+
+        if (!record) {
+            throw new Error('REFRESH_TOKEN_REVOKED');
+        }
+
+        const expiresAt = new Date(record.expires_at).getTime();
+        if (Number.isFinite(expiresAt) && expiresAt < Date.now()) {
+            await this.db.run('DELETE FROM RefreshTokens WHERE id = ?', [record.id]);
+            throw new Error('REFRESH_TOKEN_EXPIRED');
+        }
+
+        const user = await this.getUserById(record.user_id);
+
+        if (!user) {
+            await this.db.run('DELETE FROM RefreshTokens WHERE id = ?', [record.id]);
+            throw new Error('USER_NOT_FOUND');
+        }
+
+        return { payload, record, user };
+    }
+
+    async issueTokensForUser(
+        user,
+        { accessTtlMs = ACCESS_TOKEN_TTL_MS, refreshTtlMs = REFRESH_TOKEN_TTL_MS } = {}
+    ) {
+        const accessToken = this.generateAccessToken(user, accessTtlMs);
+        const refreshToken = this.generateRefreshToken(user, refreshTtlMs);
+
+        await this.storeRefreshToken(user.id, refreshToken, refreshTtlMs);
+        await this.updateLastLogin(user.id);
+
+        return { accessToken, refreshToken, accessTtlMs, refreshTtlMs };
+    }
+
+    async rotateRefreshToken(oldToken, user, options) {
+        await this.removeRefreshToken(oldToken);
+        return this.issueTokensForUser(user, options);
+    }
+
+    getCookieOptions({ accessTtlMs = ACCESS_TOKEN_TTL_MS, refreshTtlMs = REFRESH_TOKEN_TTL_MS } = {}) {
+        const base = {
+            httpOnly: true,
+            sameSite: this.config.isProduction ? 'none' : 'lax',
+            secure: this.config.isProduction,
+            path: '/',
+        };
+
+        return {
+            access: {
+                ...base,
+                maxAge: accessTtlMs,
+            },
+            refresh: {
+                ...base,
+                maxAge: refreshTtlMs,
+            },
+        };
+    }
+
+    attachTokensToResponse(res, tokens, { accessTtlMs, refreshTtlMs } = {}) {
+        const options = this.getCookieOptions({
+            accessTtlMs: accessTtlMs || tokens.accessTtlMs,
+            refreshTtlMs: refreshTtlMs || tokens.refreshTtlMs,
+        });
+
+        res.cookie('sommos_access_token', tokens.accessToken, options.access);
+        res.cookie('sommos_refresh_token', tokens.refreshToken, options.refresh);
+    }
+
+    clearAuthCookies(res) {
+        const options = this.getCookieOptions();
+        res.clearCookie('sommos_access_token', { ...options.access, maxAge: 0 });
+        res.clearCookie('sommos_refresh_token', { ...options.refresh, maxAge: 0 });
+    }
+
+    async createGuestSession({ token, pin } = {}) {
+        if (!token) {
+            throw new Error('GUEST_CODE_REQUIRED');
+        }
+
+        const invite = await this.getInviteByToken(token);
+
+        if (!invite || invite.role !== 'guest') {
+            throw new Error('INVALID_GUEST_CODE');
+        }
+
+        const user = await this.consumeInvite(token, { pin });
+
+        if (!user || user.role !== 'guest') {
+            throw new Error('INVALID_GUEST_PROFILE');
+        }
+
+        const tokens = await this.issueTokensForUser(user, {
+            accessTtlMs: GUEST_ACCESS_TOKEN_TTL_MS,
+            refreshTtlMs: GUEST_REFRESH_TOKEN_TTL_MS,
+        });
+
+        const freshUser = await this.getUserById(user.id);
+
+        return {
+            user: this.serializeUser(freshUser),
+            tokens,
+        };
+    }
+
+    async createInvite({ email, role, expiresInMs, pin }) {
+        const normalized = this.normalizeEmail(email);
+
+        if (!ROLES.includes(role)) {
+            throw new Error('INVALID_ROLE');
+        }
+
+        const token = crypto.randomBytes(48).toString('hex');
+        const tokenHash = this.hashToken(token);
+
+        const ttl = role === 'guest' ? GUEST_INVITE_TTL_MS : (expiresInMs || STANDARD_INVITE_TTL_MS);
+        const expiresAt = new Date(Date.now() + ttl).toISOString();
+
+        const pinHash = pin ? await bcrypt.hash(String(pin), BCRYPT_ROUNDS) : null;
+
+        await this.db.run('DELETE FROM Invites WHERE email = ? AND accepted_at IS NULL', [normalized]);
+
+        await this.db.run(
+            'INSERT INTO Invites (email, role, token_hash, pin_hash, expires_at) VALUES (?, ?, ?, ?, ?)',
+            [normalized, role, tokenHash, pinHash, expiresAt]
+        );
+
+        return {
+            token,
+            email: normalized,
+            role,
+            expires_at: expiresAt,
+            requires_pin: Boolean(pinHash),
+        };
+    }
+
+    async getInviteByToken(token) {
+        if (!token) {
+            return null;
+        }
+
+        const tokenHash = this.hashToken(token);
+        const invite = await this.db.get(
+            'SELECT * FROM Invites WHERE token_hash = ?',
+            [tokenHash]
+        );
+
+        if (!invite) {
+            return null;
+        }
+
+        if (invite.accepted_at && invite.role !== 'guest') {
+            return null;
+        }
+
+        const expiresAt = new Date(invite.expires_at).getTime();
+        if (Number.isFinite(expiresAt) && expiresAt < Date.now()) {
+            await this.db.run('DELETE FROM Invites WHERE id = ?', [invite.id]);
+            return null;
+        }
+
+        return invite;
+    }
+
+    async consumeInvite(token, { pin, password } = {}) {
+        const invite = await this.getInviteByToken(token);
+
+        if (!invite) {
+            throw new Error('INVALID_INVITE');
+        }
+
+        if (invite.pin_hash) {
+            if (!pin) {
+                throw new Error('PIN_REQUIRED');
+            }
+
+            const pinValid = await bcrypt.compare(String(pin), invite.pin_hash);
+            if (!pinValid) {
+                throw new Error('INVALID_PIN');
+            }
+        }
+
+        if (invite.role !== 'guest' && !password) {
+            throw new Error('PASSWORD_REQUIRED');
+        }
+
+        const normalizedEmail = this.normalizeEmail(invite.email);
+        let user = await this.getUserByEmail(normalizedEmail);
+
+        if (!user) {
+            user = await this.createUser({
+                email: normalizedEmail,
+                password: password || crypto.randomBytes(16).toString('hex'),
+                role: invite.role,
+            });
+        } else {
+            await this.updateRole(user.id, invite.role);
+            if (password) {
+                await this.updatePassword(user.id, password);
+            }
+        }
+
+        if (invite.role === 'guest') {
+            await this.db.run('UPDATE Invites SET accepted_at = COALESCE(accepted_at, CURRENT_TIMESTAMP) WHERE id = ?', [invite.id]);
+        } else {
+            await this.db.run('UPDATE Invites SET accepted_at = CURRENT_TIMESTAMP WHERE id = ?', [invite.id]);
+        }
+
+        return this.getUserById(user.id);
+    }
+}
+
+module.exports = AuthService;

--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -336,6 +336,42 @@ CREATE INDEX idx_pricebook_vintage ON PriceBook(vintage_id);
 CREATE INDEX idx_memories_context ON Memories(context_type);
 CREATE INDEX idx_explainability_type ON Explainability(request_type);
 
+-- Authentication & Authorization Tables
+
+CREATE TABLE IF NOT EXISTS Users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT NOT NULL UNIQUE,
+    password_hash TEXT,
+    role TEXT NOT NULL CHECK (role IN ('admin', 'crew', 'guest')),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    last_login DATETIME
+);
+
+CREATE TABLE IF NOT EXISTS RefreshTokens (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    token_hash TEXT NOT NULL UNIQUE,
+    expires_at DATETIME NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES Users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS Invites (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT NOT NULL,
+    role TEXT NOT NULL CHECK (role IN ('admin', 'crew', 'guest')),
+    token_hash TEXT NOT NULL UNIQUE,
+    pin_hash TEXT,
+    expires_at DATETIME NOT NULL,
+    accepted_at DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_users_email ON Users(email);
+CREATE INDEX idx_users_role ON Users(role);
+CREATE INDEX idx_refresh_tokens_user ON RefreshTokens(user_id);
+CREATE INDEX idx_invites_email ON Invites(email);
+
 -- Views for Common Queries
 
 CREATE VIEW v_current_stock AS

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,0 +1,144 @@
+const AuthService = require('../core/auth_service');
+
+const authService = new AuthService();
+
+const TRUTHY_ENV_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const FALSY_ENV_VALUES = new Set(['0', 'false', 'no', 'off']);
+
+function shouldBypassAuth() {
+    const { nodeEnv } = authService.config;
+
+    if (nodeEnv === 'production') {
+        return false;
+    }
+
+    const rawFlag = process.env.SOMMOS_AUTH_TEST_BYPASS;
+
+    if (typeof rawFlag === 'string') {
+        const normalized = rawFlag.trim().toLowerCase();
+
+        if (FALSY_ENV_VALUES.has(normalized)) {
+            return false;
+        }
+
+        if (TRUTHY_ENV_VALUES.has(normalized)) {
+            return true;
+        }
+    }
+
+    return nodeEnv === 'performance';
+}
+
+function extractAccessToken(req) {
+    if (req.cookies && req.cookies.sommos_access_token) {
+        return req.cookies.sommos_access_token;
+    }
+
+    const header = req.headers?.authorization || req.headers?.Authorization;
+    if (header && typeof header === 'string' && header.startsWith('Bearer ')) {
+        return header.slice('Bearer '.length).trim();
+    }
+
+    return null;
+}
+
+async function authenticateRequest(req) {
+    if (req.user) {
+        return req.user;
+    }
+
+    const token = extractAccessToken(req);
+
+    if (!token) {
+        if (shouldBypassAuth()) {
+            const fallbackEmail = 'test-admin@sommos.local';
+            let testUser = await authService.getUserByEmail(fallbackEmail);
+
+            if (!testUser) {
+                testUser = await authService.createUser({
+                    email: fallbackEmail,
+                    password: 'test-password',
+                    role: 'admin',
+                });
+            }
+
+            const serialized = authService.serializeUser(testUser);
+            req.user = serialized;
+            return serialized;
+        }
+
+        return null;
+    }
+
+    try {
+        const payload = authService.verifyAccessToken(token);
+        const user = await authService.getUserById(payload.sub);
+
+        if (!user) {
+            return null;
+        }
+
+        const serialized = authService.serializeUser(user);
+        req.user = serialized;
+        return serialized;
+    } catch (error) {
+        return null;
+    }
+}
+
+function unauthorized(res) {
+    return res.status(401).json({
+        success: false,
+        error: {
+            code: 'UNAUTHORIZED',
+            message: 'Authentication is required to access this resource.',
+        },
+    });
+}
+
+function forbidden(res) {
+    return res.status(403).json({
+        success: false,
+        error: {
+            code: 'FORBIDDEN',
+            message: 'You do not have permission to perform this action.',
+        },
+    });
+}
+
+function requireAuth() {
+    return async (req, res, next) => {
+        const user = await authenticateRequest(req);
+
+        if (!user) {
+            return unauthorized(res);
+        }
+
+        next();
+    };
+}
+
+function requireRole(...roles) {
+    const allowedRoles = roles.length > 0 ? roles : AuthService.Roles;
+
+    return async (req, res, next) => {
+        const user = await authenticateRequest(req);
+
+        if (!user) {
+            return unauthorized(res);
+        }
+
+        if (!allowedRoles.includes(user.role)) {
+            return forbidden(res);
+        }
+
+        next();
+    };
+}
+
+module.exports = {
+    authService,
+    authenticateRequest,
+    requireAuth,
+    requireRole,
+};

--- a/backend/middleware/validate.js
+++ b/backend/middleware/validate.js
@@ -232,6 +232,50 @@ const validators = {
       })
       .passthrough(),
   },
+  authRegister: {
+    body: z.object({
+      email: z.string().email({ message: "Must be a valid email address." }),
+      password: z
+        .string()
+        .min(8, { message: "Password must be at least 8 characters." }),
+    }),
+  },
+  authLogin: {
+    body: z.object({
+      email: z.string().email({ message: "Must be a valid email address." }),
+      password: z.string().min(1, { message: "Password is required." }),
+    }),
+  },
+  guestSession: {
+    body: z
+      .object({
+        event_code: optionalNonEmptyString,
+        invite_token: optionalNonEmptyString,
+        pin: optionalNonEmptyString,
+      })
+      .refine((payload) => payload.event_code || payload.invite_token, {
+        message: "event_code or invite_token is required.",
+        path: ["event_code"],
+      }),
+  },
+  authInvite: {
+    body: z.object({
+      email: z.string().email({ message: "Must be a valid email address." }),
+      role: z.enum(["admin", "crew", "guest"]),
+      expires_in_hours: integerLike.optional(),
+      pin: optionalNonEmptyString,
+    }),
+  },
+  authAcceptInvite: {
+    body: z.object({
+      token: nonEmptyString,
+      password: z
+        .string()
+        .min(8, { message: "Password must be at least 8 characters." })
+        .optional(),
+      pin: optionalNonEmptyString,
+    }),
+  },
 };
 
 const validate = (schemaConfig) => {

--- a/backend/server.js
+++ b/backend/server.js
@@ -47,6 +47,7 @@ const rateLimit = require('express-rate-limit');
 const compression = require('compression');
 const morgan = require('morgan');
 const path = require('path');
+const cookieParser = require('cookie-parser');
 
 const Database = require('./database/connection');
 const routes = require('./api/routes');
@@ -118,6 +119,9 @@ app.use((req, res, next) => {
 // Body parsing middleware
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));
+
+// Cookie parsing middleware for auth tokens
+app.use(cookieParser(env.auth.sessionSecret || undefined));
 
 // Compression middleware
 app.use(compression());

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -150,6 +150,111 @@ select:focus {
     animation: loadingProgress 3s ease-in-out infinite;
 }
 
+/* Authentication Screen */
+.auth-screen {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    background: rgba(5, 9, 18, 0.82);
+    backdrop-filter: blur(18px);
+    z-index: 9998;
+}
+
+.auth-card {
+    width: min(420px, 100%);
+    background: rgba(16, 26, 51, 0.92);
+    border: 1px solid rgba(148, 163, 184, 0.12);
+    border-radius: var(--border-radius-large);
+    box-shadow: 0 24px 60px rgba(8, 15, 31, 0.55);
+    padding: 2.5rem 2.25rem;
+    color: var(--text-primary);
+}
+
+.auth-card header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 2rem;
+    text-align: center;
+}
+
+.auth-card header .brand-icon {
+    font-size: 2.5rem;
+}
+
+.auth-card header h1 {
+    font-size: 1.75rem;
+    font-weight: 600;
+}
+
+.auth-card header p {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.auth-card form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.auth-card .form-group label {
+    font-weight: 500;
+    display: block;
+    margin-bottom: 0.35rem;
+}
+
+.auth-card .form-group input {
+    width: 100%;
+    padding: 0.85rem 1rem;
+    border-radius: var(--border-radius-small);
+    border: 1px solid var(--border);
+    background: rgba(19, 30, 53, 0.85);
+    color: var(--text-primary);
+    transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.auth-card .form-group input:focus {
+    border-color: var(--accent-color);
+    background: rgba(19, 30, 53, 1);
+}
+
+.auth-card .form-group input::placeholder {
+    color: var(--text-muted);
+}
+
+.auth-card .form-error {
+    margin-top: 1rem;
+    min-height: 1.25rem;
+    color: var(--error);
+    font-size: 0.95rem;
+    text-align: center;
+}
+
+.auth-card .auth-hint {
+    margin-top: 1.25rem;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.auth-card .btn.full-width {
+    width: 100%;
+}
+
+.auth-card footer {
+    margin-top: 1.5rem;
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
 /* Main App */
 .app {
     display: flex;
@@ -257,9 +362,85 @@ select:focus {
 }
 
 .nav-actions {
-    padding: 0 1.5rem;
+    padding: 0 1.5rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-top: auto;
+}
+
+.nav-action-buttons {
     display: flex;
     gap: 0.5rem;
+}
+
+.user-status {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 0.75rem 0.9rem;
+    background: rgba(19, 30, 53, 0.65);
+    border: 1px solid rgba(148, 163, 184, 0.12);
+    border-radius: var(--border-radius-medium);
+}
+
+.role-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background: rgba(156, 124, 255, 0.18);
+    color: var(--text-primary);
+    border: 1px solid rgba(156, 124, 255, 0.45);
+}
+
+.role-badge[data-role="admin"] {
+    background: rgba(233, 69, 96, 0.22);
+    border-color: rgba(233, 69, 96, 0.45);
+}
+
+.role-badge[data-role="crew"] {
+    background: rgba(56, 211, 159, 0.2);
+    border-color: rgba(56, 211, 159, 0.45);
+}
+
+.role-badge[data-role="guest"] {
+    background: rgba(246, 169, 108, 0.18);
+    border-color: rgba(246, 169, 108, 0.45);
+}
+
+.user-email {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    word-break: break-word;
+}
+
+.guest-notice {
+    padding: 0.75rem 1rem;
+    background: rgba(246, 169, 108, 0.12);
+    border: 1px solid rgba(246, 169, 108, 0.3);
+    border-radius: var(--border-radius-medium);
+    color: var(--warning);
+    font-size: 0.95rem;
+    line-height: 1.4;
+}
+
+.guest-readonly {
+    margin-top: 1rem;
+    padding: 0.75rem;
+    border-radius: var(--border-radius-small);
+    background: rgba(148, 163, 184, 0.08);
+    border: 1px dashed rgba(148, 163, 184, 0.25);
+}
+
+.guest-readonly-message {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    display: block;
 }
 
 .nav-action {
@@ -827,6 +1008,10 @@ select:focus {
 
 /* Utility Classes */
 .hidden {
+    display: none !important;
+}
+
+.hidden-by-role {
     display: none !important;
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -48,6 +48,36 @@
         </div>
     </div>
 
+    <!-- Authentication Screen -->
+    <div id="auth-screen" class="auth-screen hidden" role="dialog" aria-modal="true" aria-labelledby="auth-title">
+        <div class="auth-card">
+            <header>
+                <div class="brand-icon" aria-hidden="true">🍷</div>
+                <h1 id="auth-title">Sign in to SommOS</h1>
+                <p>Access cellar intelligence, procurement workflows, and guest experiences.</p>
+            </header>
+
+            <form id="login-form" novalidate>
+                <div class="form-group">
+                    <label for="login-email">Email</label>
+                    <input type="email" id="login-email" name="email" autocomplete="username" placeholder="crew@yacht.com" required>
+                </div>
+                <div class="form-group">
+                    <label for="login-password">Password</label>
+                    <input type="password" id="login-password" name="password" autocomplete="current-password" placeholder="Enter your password" required>
+                </div>
+                <button type="submit" class="btn primary full-width" id="login-submit">Sign In</button>
+            </form>
+
+            <p id="login-error" class="form-error" role="alert" aria-live="assertive"></p>
+
+            <footer>
+                <span>Guest access available?</span>
+                <span>Request an event code from the crew.</span>
+            </footer>
+        </div>
+    </div>
+
     <!-- Main App Container -->
     <div id="app" class="app hidden">
         <!-- Navigation -->
@@ -70,7 +100,7 @@
                     <span class="nav-icon" aria-hidden="true">📦</span>
                     <span class="nav-text">Inventory</span>
                 </button>
-                <button class="nav-item" data-view="procurement" role="menuitem" aria-label="Navigate to Procurement">
+                <button class="nav-item" data-view="procurement" role="menuitem" aria-label="Navigate to Procurement" data-role-allow="admin,crew">
                     <span class="nav-icon" aria-hidden="true">🛒</span>
                     <span class="nav-text">Procurement</span>
                 </button>
@@ -81,12 +111,24 @@
             </div>
             
             <div class="nav-actions">
-                <button class="nav-action" id="sync-btn" title="Sync Data">
-                    <span class="sync-icon">🔄</span>
-                </button>
-                <button class="nav-action" id="settings-btn" title="Settings">
-                    <span>⚙️</span>
-                </button>
+                <div class="user-status">
+                    <span id="user-role-badge" class="role-badge" aria-live="polite">SIGNED OUT</span>
+                    <span id="user-email" class="user-email"></span>
+                </div>
+                <div id="guest-notice" class="guest-notice hidden-by-role" data-role-allow="guest">
+                    Guest browsing is read-only. Contact the crew for upgrade.
+                </div>
+                <div class="nav-action-buttons">
+                    <button class="nav-action" id="sync-btn" title="Sync Data" data-role-allow="admin,crew">
+                        <span class="sync-icon">🔄</span>
+                    </button>
+                    <button class="nav-action" id="settings-btn" title="Settings">
+                        <span>⚙️</span>
+                    </button>
+                    <button class="nav-action" id="logout-btn" title="Sign out">
+                        <span>🚪</span>
+                    </button>
+                </div>
             </div>
         </nav>
 
@@ -141,7 +183,7 @@
                             <span class="btn-icon">⚡</span>
                             Quick Pairing
                         </button>
-                        <button class="action-btn" data-action="record-consumption">
+                        <button class="action-btn" data-action="record-consumption" data-role-allow="admin,crew">
                             <span class="btn-icon">📝</span>
                             Record Service
                         </button>
@@ -402,7 +444,7 @@
             </div>
 
             <!-- Other views would continue here... -->
-            <div id="procurement-view" class="view">
+            <div id="procurement-view" class="view" data-role-allow="admin,crew">
                 <div class="view-header">
                     <h1>Procurement Assistant</h1>
                     <p class="view-subtitle">Smart wine purchasing recommendations powered by AI</p>

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,6 +41,11 @@ module.exports = {
       testEnvironment: 'node'
     },
     {
+      displayName: 'Auth API Tests',
+      testMatch: ['**/tests/auth/**/*.test.js'],
+      testEnvironment: 'node'
+    },
+    {
       displayName: 'API Contract Tests',
       testMatch: ['**/tests/api/**/*.test.js'],
       testEnvironment: 'node'

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.5.0",
-        "bcryptjs": "^2.4.3",
+        "bcrypt": "^5.1.1",
         "compression": "^1.8.1",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
@@ -1213,6 +1214,110 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -1487,8 +1592,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -1544,7 +1648,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -1557,7 +1660,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1575,7 +1677,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/agentkeepalive": {
@@ -1625,7 +1726,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1665,8 +1765,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
       "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/are-we-there-yet": {
       "version": "3.0.1",
@@ -1847,7 +1946,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -1898,10 +1996,24 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
-    "node_modules/bcryptjs": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+    "node_modules/bcrypt": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
+      "integrity": "sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.11",
+        "node-addon-api": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/bcrypt/node_modules/node-addon-api": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
       "license": "MIT"
     },
     "node_modules/bidi-js": {
@@ -1975,7 +2087,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2370,7 +2481,6 @@
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "color-support": "bin.js"
       }
@@ -2440,7 +2550,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/concurrently": {
@@ -2475,8 +2584,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -2510,6 +2618,28 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2730,8 +2860,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -2891,7 +3020,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -3401,7 +3529,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -3540,7 +3667,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -3630,8 +3756,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -3741,7 +3866,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -3755,7 +3879,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3773,7 +3896,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/human-signals": {
@@ -3887,7 +4009,6 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -3974,7 +4095,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5566,7 +5686,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -5827,6 +5946,48 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-gyp": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
@@ -5974,7 +6135,6 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -6246,7 +6406,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6714,7 +6873,6 @@
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -6849,8 +7007,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -6970,7 +7127,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/simple-concat": {
@@ -7257,7 +7413,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7272,7 +7427,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7982,7 +8136,6 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
       "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^1.5.0",
-    "bcryptjs": "^2.4.3",
+    "bcrypt": "^5.1.1",
     "compression": "^1.8.1",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",

--- a/tests/auth/authentication.test.js
+++ b/tests/auth/authentication.test.js
@@ -1,0 +1,248 @@
+const path = require('path');
+const fs = require('fs');
+const request = require('supertest');
+
+const schemaPath = path.join(__dirname, '../../backend/database/schema.sql');
+
+describe('Authentication lifecycle', () => {
+  let app;
+  let db;
+  let authService;
+  let requireAuth;
+  let requireRole;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = 'test-jwt-secret';
+    process.env.SESSION_SECRET = 'test-session-secret';
+    process.env.DATABASE_PATH = ':memory:';
+    process.env.SOMMOS_AUTH_TEST_BYPASS = 'false';
+
+    jest.resetModules();
+
+    const Database = require('../../backend/database/connection');
+    Database.instance = null;
+    db = Database.getInstance(':memory:');
+    await db.initialize();
+
+    const schemaSql = fs.readFileSync(schemaPath, 'utf8');
+    await db.exec(schemaSql);
+
+    const authMiddleware = require('../../backend/middleware/auth');
+    authService = authMiddleware.authService;
+    requireAuth = authMiddleware.requireAuth;
+    requireRole = authMiddleware.requireRole;
+
+    const express = require('express');
+    const cookieParser = require('cookie-parser');
+    const authRouter = require('../../backend/api/auth');
+
+    app = express();
+    app.use(express.json());
+    app.use(cookieParser(process.env.SESSION_SECRET));
+    app.use('/api/auth', authRouter);
+
+    app.get('/protected', requireAuth(), (req, res) => {
+      res.json({ success: true, user: req.user });
+    });
+
+    app.post('/admin', requireRole('admin'), (req, res) => {
+      res.json({ success: true, user: req.user });
+    });
+  });
+
+  beforeEach(async () => {
+    await db.exec('DELETE FROM RefreshTokens; DELETE FROM Invites; DELETE FROM Users;');
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await db.close();
+    }
+  });
+
+  const parseCookieValue = (cookies, name) => {
+    if (!Array.isArray(cookies)) {
+      return null;
+    }
+
+    const target = cookies.find((cookie) => cookie.startsWith(`${name}=`));
+    if (!target) {
+      return null;
+    }
+
+    const [raw] = target.split(';');
+    const [, ...valueParts] = raw.split('=');
+    return valueParts.join('=');
+  };
+
+  test('POST /api/auth/login issues httpOnly cookies and updates metadata', async () => {
+    const agent = request.agent(app);
+
+    const password = 'CrewPass!234';
+    const user = await authService.createUser({
+      email: 'crew@example.com',
+      password,
+      role: 'crew',
+    });
+
+    const response = await agent
+      .post('/api/auth/login')
+      .send({ email: 'crew@example.com', password })
+      .expect(200);
+
+    expect(response.body.success).toBe(true);
+    expect(response.body.data).toMatchObject({
+      email: 'crew@example.com',
+      role: 'crew',
+    });
+
+    const cookies = response.headers['set-cookie'];
+    expect(cookies).toBeDefined();
+
+    const accessCookie = cookies.find((cookie) => cookie.startsWith('sommos_access_token='));
+    const refreshCookie = cookies.find((cookie) => cookie.startsWith('sommos_refresh_token='));
+
+    expect(accessCookie).toBeDefined();
+    expect(accessCookie).toContain('HttpOnly');
+    expect(accessCookie).toContain('SameSite=Lax');
+    expect(accessCookie).not.toContain('Secure');
+
+    expect(refreshCookie).toBeDefined();
+    expect(refreshCookie).toContain('HttpOnly');
+    expect(refreshCookie).toContain('SameSite=Lax');
+    expect(refreshCookie).not.toContain('Secure');
+
+    const refreshTokenValue = parseCookieValue(cookies, 'sommos_refresh_token');
+    const storedToken = await db.get('SELECT token_hash FROM RefreshTokens WHERE user_id = ?', [user.id]);
+    expect(storedToken).toBeDefined();
+    expect(storedToken.token_hash).toHaveLength(64);
+    expect(storedToken.token_hash).not.toBe(refreshTokenValue);
+
+    const updatedUser = await authService.getUserById(user.id);
+    expect(updatedUser.last_login).not.toBeNull();
+  });
+
+  test('POST /api/auth/refresh rotates refresh tokens and reissues cookies', async () => {
+    const agent = request.agent(app);
+    const password = 'CrewRefresh!42';
+    const user = await authService.createUser({
+      email: 'rotate@example.com',
+      password,
+      role: 'crew',
+    });
+
+    const loginResponse = await agent
+      .post('/api/auth/login')
+      .send({ email: 'rotate@example.com', password })
+      .expect(200);
+
+    const loginCookies = loginResponse.headers['set-cookie'];
+    const originalRefreshValue = parseCookieValue(loginCookies, 'sommos_refresh_token');
+    const originalTokenRow = await db.get('SELECT token_hash FROM RefreshTokens WHERE user_id = ?', [user.id]);
+
+    const refreshResponse = await agent.post('/api/auth/refresh').expect(200);
+    const refreshCookies = refreshResponse.headers['set-cookie'];
+    const rotatedRefreshValue = parseCookieValue(refreshCookies, 'sommos_refresh_token');
+
+    expect(rotatedRefreshValue).toBeDefined();
+    expect(rotatedRefreshValue).not.toBe(originalRefreshValue);
+
+    const tokenRows = await db.all('SELECT token_hash FROM RefreshTokens WHERE user_id = ?', [user.id]);
+    expect(tokenRows).toHaveLength(1);
+    expect(tokenRows[0].token_hash).not.toBe(originalTokenRow.token_hash);
+  });
+
+  test('POST /api/auth/refresh rejects invalid refresh tokens and clears cookies', async () => {
+    const response = await request(app)
+      .post('/api/auth/refresh')
+      .set('Cookie', 'sommos_refresh_token=invalid-token')
+      .expect(401);
+
+    expect(response.body.success).toBe(false);
+
+    const cookies = response.headers['set-cookie'];
+    const clearedRefresh = cookies.find((cookie) => cookie.startsWith('sommos_refresh_token='));
+    expect(clearedRefresh).toBeDefined();
+    expect(clearedRefresh).toContain('Max-Age=0');
+  });
+
+  test('POST /api/auth/logout revokes refresh tokens and removes cookies', async () => {
+    const agent = request.agent(app);
+    const password = 'CrewLogout!42';
+    const user = await authService.createUser({
+      email: 'logout@example.com',
+      password,
+      role: 'crew',
+    });
+
+    await agent
+      .post('/api/auth/login')
+      .send({ email: 'logout@example.com', password })
+      .expect(200);
+
+    let tokenRows = await db.all('SELECT token_hash FROM RefreshTokens WHERE user_id = ?', [user.id]);
+    expect(tokenRows).toHaveLength(1);
+
+    const logoutResponse = await agent.post('/api/auth/logout').expect(200);
+    expect(logoutResponse.body.success).toBe(true);
+
+    const cookies = logoutResponse.headers['set-cookie'];
+    const clearedAccess = cookies.find((cookie) => cookie.startsWith('sommos_access_token='));
+    const clearedRefresh = cookies.find((cookie) => cookie.startsWith('sommos_refresh_token='));
+
+    expect(clearedAccess).toBeDefined();
+    expect(clearedAccess).toContain('Max-Age=0');
+    expect(clearedRefresh).toBeDefined();
+    expect(clearedRefresh).toContain('Max-Age=0');
+
+    tokenRows = await db.all('SELECT token_hash FROM RefreshTokens WHERE user_id = ?', [user.id]);
+    expect(tokenRows).toHaveLength(0);
+
+    await agent.get('/protected').expect(401);
+  });
+
+  test('requireAuth and requireRole enforce RBAC expectations', async () => {
+    await request(app).get('/protected').expect(401);
+
+    const guestPassword = 'GuestAccess!9';
+    await authService.createUser({
+      email: 'guest@example.com',
+      password: guestPassword,
+      role: 'guest',
+    });
+
+    const guestAgent = request.agent(app);
+    await guestAgent
+      .post('/api/auth/login')
+      .send({ email: 'guest@example.com', password: guestPassword })
+      .expect(200);
+
+    const protectedResponse = await guestAgent.get('/protected').expect(200);
+    expect(protectedResponse.body.user).toMatchObject({
+      email: 'guest@example.com',
+      role: 'guest',
+    });
+
+    await guestAgent.post('/admin').expect(403);
+
+    const adminPassword = 'AdminPower!55';
+    await authService.createUser({
+      email: 'admin@example.com',
+      password: adminPassword,
+      role: 'admin',
+    });
+
+    const adminAgent = request.agent(app);
+    await adminAgent
+      .post('/api/auth/login')
+      .send({ email: 'admin@example.com', password: adminPassword })
+      .expect(200);
+
+    const adminResponse = await adminAgent.post('/admin').expect(200);
+    expect(adminResponse.body.user).toMatchObject({
+      email: 'admin@example.com',
+      role: 'admin',
+    });
+  });
+});

--- a/tests/backend/api.test.js
+++ b/tests/backend/api.test.js
@@ -1,6 +1,8 @@
 // SommOS Backend API Tests
 // Comprehensive test suite for all API endpoints
 
+process.env.SOMMOS_AUTH_TEST_BYPASS = process.env.SOMMOS_AUTH_TEST_BYPASS || 'true';
+
 const request = require('supertest');
 
 // Mock the database and core modules to avoid external dependencies during testing


### PR DESCRIPTION
## Summary
- gate the authentication middleware bypass behind an explicit environment flag so tests can enforce full token checks
- register a dedicated auth test project in Jest and add regression coverage for login, refresh, logout, and RBAC flows including cookie assertions
- keep legacy backend endpoint tests working by explicitly enabling the bypass when their mocked environment boots

## Testing
- ./node_modules/.bin/jest tests/auth --runInBand *(fails: Node binary unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db04d00d20832bb7f042249a4cefdc