### PR TITLE
Add resilience tests for OpenMeteo service and inventory fallback

### DIFF
--- a/backend/api/openapi.yaml
+++ b/backend/api/openapi.yaml
@@ -1540,6 +1540,69 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /vintage/{id}/refresh-weather:
+    get:
+      tags: [Vintage Intelligence]
+      summary: Refresh cached weather analysis for a vintage.
+      security:
+        - accessTokenCookie: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: Identifier of the vintage to refresh.
+          schema:
+            type: integer
+        - in: query
+          name: force
+          required: false
+          description: Force bypass of caches to retrieve fresh weather data.
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Weather data refreshed successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    properties:
+                      weatherAnalysis:
+                        description: Processed weather metrics for the requested vintage.
+                        type: object
+                        additionalProperties: true
+                      metadata:
+                        type: object
+                        properties:
+                          forceRefresh:
+                            type: boolean
+                          vineyardAlias:
+                            type: string
+                            nullable: true
+        '404':
+          description: Vintage not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Weather refresh could not be completed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Unexpected failure refreshing weather data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /vintage/procurement-recommendations:
     get:
       tags: [Vintage Intelligence]

--- a/backend/core/weather_analysis.js
+++ b/backend/core/weather_analysis.js
@@ -591,6 +591,22 @@ class WeatherAnalysisService {
         }
     }
 
+    async clearCachedWeatherAnalysis(region, year) {
+        if (!region || !year) {
+            return;
+        }
+
+        try {
+            await this.db.run(
+                `DELETE FROM WeatherVintage WHERE LOWER(region) = LOWER(?) AND year = ?`,
+                [region, year]
+            );
+            console.log(`Cleared cached weather analysis for ${region} ${year}`);
+        } catch (error) {
+            console.error('Error clearing cached weather analysis:', error.message);
+        }
+    }
+
     sanitizeForJson(data) {
         return Object.fromEntries(
             Object.entries(data)

--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -97,6 +97,15 @@ CREATE TABLE WeatherVintage (
     UNIQUE(region, year)
 );
 
+CREATE TABLE IF NOT EXISTS WeatherCache (
+    key TEXT PRIMARY KEY,
+    payload TEXT NOT NULL,
+    fetched_at INTEGER NOT NULL,
+    ttl INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_weather_cache_expiry ON WeatherCache(fetched_at);
+
 CREATE TABLE RegionCalendar (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     region TEXT NOT NULL,

--- a/backend/middleware/validate.js
+++ b/backend/middleware/validate.js
@@ -195,6 +195,16 @@ const validators = {
       wine_id: z.union([nonEmptyString, integerLike]),
     }),
   },
+  vintageRefreshWeather: {
+    params: z.object({
+      id: integerLike,
+    }),
+    query: z
+      .object({
+        force: booleanLike.optional(),
+      })
+      .passthrough(),
+  },
   vintageBatchEnrich: {
     body: passthroughObject({
       filters: generalObject.optional(),

--- a/tests/backend/inventory-enrichment-resilience.test.js
+++ b/tests/backend/inventory-enrichment-resilience.test.js
@@ -1,0 +1,54 @@
+jest.mock('../../backend/config/env', () => ({
+    getConfig: () => ({
+        nodeEnv: 'development',
+        openMeteo: { baseUrl: 'https://mock.open-meteo.test' },
+        openAI: { apiKey: null },
+        database: { path: ':memory:' },
+        features: { disableExternalCalls: true }
+    })
+}));
+
+jest.mock('../../backend/database/connection');
+
+const MockDatabase = require('../../backend/database/connection');
+const InventoryManager = require('../../backend/core/inventory_manager');
+
+describe('Inventory enrichment does not block core actions', () => {
+    let manager;
+
+    beforeEach(() => {
+        MockDatabase.getInstance().reset();
+        manager = new InventoryManager(MockDatabase.getInstance());
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('addWineToInventory succeeds even when enrichment fails', async () => {
+        const wineData = {
+            name: 'Test Wine',
+            producer: 'Test Estate',
+            region: 'Test Region',
+            country: 'Test Country',
+            wine_type: 'Red'
+        };
+        const vintageData = { year: 2020 };
+        const stockData = { quantity: 6, location: 'main-cellar', cost_per_bottle: 25, created_by: 'tester' };
+
+        jest.spyOn(manager, 'findOrCreateWine').mockResolvedValue({ id: 'wine-1', ...wineData });
+        jest.spyOn(manager, 'findOrCreateVintage').mockResolvedValue({ id: 'vintage-1', year: 2020 });
+        jest.spyOn(manager, 'addToStock').mockResolvedValue();
+        jest.spyOn(manager, 'recordTransaction').mockResolvedValue();
+        jest.spyOn(manager.vintageIntelligence, 'enrichWineData').mockRejectedValue(new Error('service unavailable'));
+
+        const result = await manager.addWineToInventory(wineData, vintageData, stockData, { origin: 'inventory.test' });
+
+        expect(result.success).toBe(true);
+        expect(result.enrichmentError).toBe('service unavailable');
+        expect(manager.findOrCreateWine).toHaveBeenCalled();
+        expect(manager.findOrCreateVintage).toHaveBeenCalled();
+        expect(manager.addToStock).toHaveBeenCalled();
+        expect(manager.recordTransaction).toHaveBeenCalled();
+    });
+});

--- a/tests/backend/open-meteo-service.test.js
+++ b/tests/backend/open-meteo-service.test.js
@@ -1,0 +1,135 @@
+jest.mock('../../backend/config/env', () => ({
+    getConfig: () => ({
+        nodeEnv: 'development',
+        openMeteo: {
+            baseUrl: 'https://mock.open-meteo.test',
+            rateLimit: { maxRequests: 2, windowMs: 50 }
+        },
+        openAI: { apiKey: null },
+        database: { path: ':memory:' },
+        features: { disableExternalCalls: false }
+    })
+}));
+
+jest.mock('../../backend/database/connection');
+jest.mock('axios');
+
+const axios = require('axios');
+const MockDatabase = require('../../backend/database/connection');
+const OpenMeteoService = require('../../backend/core/open_meteo_service');
+
+const buildProcessedPayload = () => ({
+    gdd: 1234,
+    totalRainfall: 456,
+    phenology: { budbreak: '2020-04-15' }
+});
+
+const buildRawResponse = () => {
+    const length = 100;
+    const buildArray = (value) => Array.from({ length }, () => value);
+    return {
+        data: {
+            daily: {
+                time: Array.from({ length }, (_, index) => `2019-04-${String((index % 30) + 1).padStart(2, '0')}`),
+                temperature_2m_max: buildArray(25),
+                temperature_2m_min: buildArray(12),
+                temperature_2m_mean: buildArray(18),
+                apparent_temperature_max: buildArray(24),
+                apparent_temperature_min: buildArray(11),
+                apparent_temperature_mean: buildArray(17),
+                precipitation_sum: buildArray(2),
+                rain_sum: buildArray(1),
+                snowfall_sum: buildArray(0),
+                sunshine_duration: buildArray(8),
+                daylight_duration: buildArray(12),
+                shortwave_radiation_sum: buildArray(5),
+                wind_speed_10m_max: buildArray(15),
+                wind_gusts_10m_max: buildArray(25),
+                wind_direction_10m_dominant: buildArray(180),
+                pressure_msl_mean: buildArray(1013),
+                surface_pressure_mean: buildArray(1010),
+                vapour_pressure_deficit_max: buildArray(0.5),
+                et0_fao_evapotranspiration: buildArray(3),
+                weather_code: buildArray(0)
+            }
+        }
+    };
+};
+
+describe('OpenMeteoService resilience guardrails', () => {
+    let service;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        MockDatabase.getInstance().reset();
+        service = new OpenMeteoService();
+        jest.spyOn(service, 'getRegionCoordinates').mockResolvedValue({
+            latitude: 44.1234,
+            longitude: -0.9876
+        });
+        jest.spyOn(service, 'delay').mockResolvedValue();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('returns null and records explanation after repeated timeouts', async () => {
+        const timeoutError = new Error('timeout');
+        timeoutError.code = 'ECONNABORTED';
+        axios.get.mockImplementation(() => Promise.reject(timeoutError));
+
+        const recordSpy = jest.spyOn(service, 'recordWeatherExplanation').mockResolvedValue();
+
+        const result = await service.getVintageWeatherData('Bordeaux', 2020, { vineyardAlias: 'Clos Test' });
+
+        expect(result).toBeNull();
+        expect(axios.get).toHaveBeenCalledTimes(service.retryConfig.attempts);
+        expect(recordSpy).toHaveBeenCalledWith(expect.objectContaining({
+            factors: ['api_error']
+        }));
+    });
+
+    test('retries on 429 responses and returns processed payload when retry succeeds', async () => {
+        axios.get
+            .mockRejectedValueOnce({ response: { status: 429 }, message: 'Too Many Requests' })
+            .mockResolvedValueOnce(buildRawResponse());
+
+        jest.spyOn(service, 'shouldSkipEnrichment').mockReturnValue(false);
+        jest.spyOn(service, 'processVintageWeatherData').mockReturnValue(buildProcessedPayload());
+        jest.spyOn(service, 'isDataQualityAcceptable').mockReturnValue(true);
+        jest.spyOn(service, 'setCachedWeatherData').mockResolvedValue();
+        const explanationSpy = jest.spyOn(service, 'recordWeatherExplanation').mockResolvedValue();
+
+        const result = await service.getVintageWeatherData('Burgundy', 2019, { vineyardAlias: 'Domaine Retry' });
+
+        expect(result).toEqual(buildProcessedPayload());
+        expect(axios.get).toHaveBeenCalledTimes(2);
+        expect(explanationSpy).not.toHaveBeenCalled();
+    });
+
+    test('uses regional cache fallback when vineyard alias cache misses', async () => {
+        const cachedPayload = buildProcessedPayload();
+        const cacheSpy = jest
+            .spyOn(service, 'getCachedWeatherData')
+            .mockImplementation(async (key) => {
+                if (key.includes('alias:domaine_retry')) {
+                    return null;
+                }
+                if (key.includes('alias:burgundy')) {
+                    return cachedPayload;
+                }
+                return null;
+            });
+        const explanationSpy = jest.spyOn(service, 'recordWeatherExplanation').mockResolvedValue();
+
+        const result = await service.getVintageWeatherData('Burgundy', 2018, { vineyardAlias: 'Domaine Retry' });
+
+        expect(result).toBe(cachedPayload);
+        expect(cacheSpy).toHaveBeenCalledTimes(2);
+        expect(explanationSpy).toHaveBeenCalledWith(expect.objectContaining({
+            factors: ['regional_cache_fallback']
+        }));
+        expect(axios.get).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- extend the mocked database connection with WeatherCache storage so OpenMeteoService can exercise cache flows in tests
- add OpenMeteoService resilience tests that simulate timeouts, rate limit retries, and regional cache fallbacks
- add an inventory manager regression test to ensure enrichment failures never block core stock operations

## Testing
- npx jest tests/backend/open-meteo-service.test.js --runTestsByPath --no-coverage
- npx jest tests/backend/inventory-enrichment-resilience.test.js --runTestsByPath --no-coverage

------
https://chatgpt.com/codex/tasks/task_e_68db2a96f268832bade4dac6c40f9dd5