### PR TITLE
Configure main branch protection rules

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,20 @@
+branches:
+  - name: main
+    protection:
+      required_status_checks:
+        strict: true
+        contexts:
+          - lint
+          - test
+          - build
+          - spec-parity
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        require_code_owner_reviews: false
+        dismiss_stale_reviews: false
+        require_last_push_approval: false
+      require_conversation_resolution: true
+      required_linear_history: true
+      allow_force_pushes: false
+      allow_deletions: false
+      enforce_admins: true


### PR DESCRIPTION
## Summary
- define branch protection for `main` via the GitHub settings configuration
- require pull requests with one review, conversation resolution, and linear history
- enforce status checks for lint, test, build, and spec-parity workflows before merging

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68db38b583f0832b971f60bc2f93e542